### PR TITLE
Remove obsolete "5" build number prefix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,7 @@ trigger:
 pr:
 - master
 
-# Use "5" prefix to avoid colliding with Core-Setup builds that still produce WindowsDesktop.
-name: $(Date:yyyyMMdd)$(Rev:.5r)
+name: $(Date:yyyyMMdd)$(Rev:.r)
 
 variables:
   - name: TeamName


### PR DESCRIPTION
This was for:

> Use "5" prefix to avoid colliding with Core-Setup builds that still produce WindowsDesktop.

Now that WindowsDesktop is removed from Core-Setup, it is no longer necessary.

The 5 can also break builds: once 10 or more builds happen, the build number becomes ".510", which is an invalid format according to Arcade, causing the build to fail.

/cc @MichaelSimons 