### PR TITLE
Add closure validation via ref/runtime packs

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -121,6 +121,14 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>8db04f8b884947b9e5e3bc2be44bd9c2d46c2bfd</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19462.5" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>2718e02209b325d3d188cb529c85a9fba94557d9</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19462.5" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>2718e02209b325d3d188cb529c85a9fba94557d9</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.19517.8">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,6 +30,9 @@
     <MicrosoftDotNetVersionToolsTasksPackageVersion>5.0.0-beta.19517.8</MicrosoftDotNetVersionToolsTasksPackageVersion>
     <!-- sourcelink -->
     <MicrosoftSourceLinkVersion>1.0.0-beta2-19367-01</MicrosoftSourceLinkVersion>
+    <!-- core-setup -->
+    <MicrosoftNETCoreAppRefVersion>5.0.0-alpha1.19462.5</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-alpha1.19462.5</MicrosoftNETCoreAppRuntimewinx64Version>
     <!-- corefx -->
     <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha1.19518.4</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha1.19518.4</MicrosoftNETCoreTargetsPackageVersion>

--- a/pkg/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/pkg/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -16,15 +16,7 @@
       WPF/WinForms packages don't declare their transitive dependencies and the depproj has to fill
       it in correctly. Being wrong means dependency failures at runtime.
     -->
-    <!-- <SkipValidatePackage>false</SkipValidatePackage> -->
-    <!--
-      Turn off package validation: while in Core-Setup, this depended on extracting the list of
-      NETCoreApp DLLs from netcoreapp.depproj. We need to figure out how to implement this based on
-      a restored package, instead. (Should be somewhat simple: a target that depends on NuGet's
-      content restoration target that filters found assets based on origin package and puts them in
-      the list of ignored references.)
-    -->
-    <SkipValidatePackage>true</SkipValidatePackage>
+    <SkipValidatePackage>false</SkipValidatePackage>
 
     <IsShipping>false</IsShipping>
   </PropertyGroup>
@@ -47,6 +39,31 @@
     <!-- We don't have a ref assembly for DirectWriteForwarder -->
     <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="DirectWriteForwarder" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(MicrosoftNETCoreAppRefVersion)]" />
+    <PackageDownload Include="@(RestoreBuildRID -> 'Microsoft.NETCore.App.Runtime.%(Identity)')" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" />
+  </ItemGroup>
+
+  <Target Name="GetNETCoreAppIgnoredReference"
+          BeforeTargets="VerifyClosure">
+    <PropertyGroup>
+      <RefPackageDir>$(NuGetPackageRoot)Microsoft.NETCore.App.Ref\$(MicrosoftNETCoreAppRefVersion)\</RefPackageDir>
+      <RuntimePackageDir>$(NuGetPackageRoot)Microsoft.NETCore.App.Runtime.$(PackageTargetRuntime)\$(MicrosoftNETCoreAppRuntimewinx64Version)\</RuntimePackageDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <IgnoredReferenceFile
+        Condition="'$(PackageTargetRuntime)' == ''"
+        Include="$(RefPackageDir)ref\$(NETCoreAppFramework)\*.dll" />
+
+      <IgnoredReferenceFile
+        Condition="'$(PackageTargetRuntime)' != ''"
+        Include="$(RuntimePackageDir)runtimes\$(PackageTargetRuntime)\lib\$(NETCoreAppFramework)\*.dll" />
+
+      <IgnoredReference Include="@(IgnoredReferenceFile -> '%(Filename)')" />
+    </ItemGroup>
+  </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/windowsdesktop/issues/3. Turns ref/runtime closure validation back on in this repo, using the NETCoreApp targeting and runtime packs rather than a project reference.

For reference, the project-to-project way of doing this is still active in core-setup 3.0/3.1 currently: [Microsoft.WindowsDesktop.App.pkgproj#L43](https://github.com/dotnet/core-setup/blob/32085cbc728e1016c9d6a7bc105845f0f9eb6b47/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj#L43).

This adds the dependency on Core-Setup, which I set up with a coherent parent. (See https://github.com/dotnet/windowsdesktop/issues/20. When WinForms updates to a new Core-Setup, WPF and now WindowsDesktop will also use that version to stay coherent.)

[`PackageDownload`](https://github.com/NuGet/Home/wiki/[Spec]-PackageDownload-support) is the way to get framework packs--they aren't allowed in `PackageReference`s. NuGet only downloads them into the cache, I have to resolve assets myself. It also requires an exact-match version, which is the `[]`. This has the side effect of being easy to understand. 🙂 