### PR TITLE
Add extra compatibility packages for WPF/WinForms users

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -129,6 +129,19 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>2718e02209b325d3d188cb529c85a9fba94557d9</Sha>
     </Dependency>
+    <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19527.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>17c14aa2b50cfb5920d03ea8835c9a4932b5359c</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19527.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>17c14aa2b50cfb5920d03ea8835c9a4932b5359c</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Pipes.AccessControl" Version="4.5.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.19527.3">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,6 +79,10 @@
     <NugetPackagingPackageVersion>4.9.4</NugetPackagingPackageVersion>
     <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
+    <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
+    <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha.1.19527.5</MicrosoftWin32RegistryAccessControlVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-alpha.1.19527.5</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/pkg/windowsdesktop/Directory.Build.targets
+++ b/pkg/windowsdesktop/Directory.Build.targets
@@ -1,0 +1,12 @@
+<Project>
+
+  <Target Name="GetNETCoreAppPackDirs">
+    <PropertyGroup>
+      <RefPackageDir>$(NuGetPackageRoot)Microsoft.NETCore.App.Ref\$(MicrosoftNETCoreAppRefVersion)\</RefPackageDir>
+      <RuntimePackageDir>$(NuGetPackageRoot)Microsoft.NETCore.App.Runtime.$(PackageTargetRuntime)\$(MicrosoftNETCoreAppRuntimewinx64Version)\</RuntimePackageDir>
+    </PropertyGroup>
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))\Directory.Build.targets" />
+
+</Project>

--- a/pkg/windowsdesktop/pkg/Directory.Build.props
+++ b/pkg/windowsdesktop/pkg/Directory.Build.props
@@ -20,6 +20,7 @@
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="Accessibility.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="Microsoft.Win32.Registry.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.Registry.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.SystemEvents.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="PresentationCore.dll" Profile="WPF" />
@@ -35,10 +36,15 @@
     <FrameworkListFileClass Include="System.CodeDom.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Configuration.ConfigurationManager.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Diagnostics.EventLog.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Diagnostics.PerformanceCounter.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.DirectoryServices.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Drawing.Common.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Drawing.Design.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Drawing.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.IO.FileSystem.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.IO.Packaging.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.IO.Pipes.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Printing.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Resources.Extensions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.AccessControl.dll" Profile="WindowsForms;WPF" />
@@ -48,6 +54,7 @@
     <FrameworkListFileClass Include="System.Security.Cryptography.Xml.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Principal.Windows.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Windows.Extensions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />

--- a/pkg/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/pkg/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -46,12 +46,8 @@
   </ItemGroup>
 
   <Target Name="GetNETCoreAppIgnoredReference"
-          BeforeTargets="VerifyClosure">
-    <PropertyGroup>
-      <RefPackageDir>$(NuGetPackageRoot)Microsoft.NETCore.App.Ref\$(MicrosoftNETCoreAppRefVersion)\</RefPackageDir>
-      <RuntimePackageDir>$(NuGetPackageRoot)Microsoft.NETCore.App.Runtime.$(PackageTargetRuntime)\$(MicrosoftNETCoreAppRuntimewinx64Version)\</RuntimePackageDir>
-    </PropertyGroup>
-
+          BeforeTargets="VerifyClosure"
+          DependsOnTargets="GetNETCoreAppPackDirs">
     <ItemGroup>
       <IgnoredReferenceFile
         Condition="'$(PackageTargetRuntime)' == ''"

--- a/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.SharedFx.sfxproj
+++ b/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.SharedFx.sfxproj
@@ -10,4 +10,20 @@
     <PkgProjectReference Include="..\pkg\Microsoft.WindowsDesktop.App.pkgproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(MicrosoftNETCoreAppRefVersion)]" />
+  </ItemGroup>
+
+  <!--
+    Keep the platform manifest from the base shared framework. It ensures the WindowsDesktop shared
+    framework doesn't carry runtime assemblies the base framework (NETCoreApp) already provides.
+  -->
+  <Target Name="KeepNETCoreAppPlatformManifest"
+          AfterTargets="RemovePlatformManifests"
+          DependsOnTargets="GetNETCoreAppPackDirs">
+    <ItemGroup>
+      <PackageConflictPlatformManifests Include="$(RefPackageDir)data\PlatformManifest.txt" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/pkg/windowsdesktop/src/windowsdesktop.depproj
+++ b/pkg/windowsdesktop/src/windowsdesktop.depproj
@@ -5,12 +5,18 @@
     <PackageReference Include="Microsoft.DotNet.Wpf.GitHub" Version="$(MicrosoftDotNetWpfGitHubPackageVersion)" />
     <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsPackageVersion)" />
 
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="$(MicrosoftWin32RegistryAccessControlVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsVersion)" />
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounterVersion)" />
+    <PackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
@@ -19,16 +25,8 @@
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
+    <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <RuntimeOnlyPackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
-    <RuntimeOnlyPackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
-    <RuntimeOnlyPackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
-    <RuntimeOnlyPackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
-
-    <PackageReference Include="@(RuntimeOnlyPackageReference)" ExcludeAssets="Compile" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
For https://github.com/dotnet/windowsdesktop/issues/7.

This brings the set of references shipped by dotnet/windowsdesktop up to par vs. dotnet/core-setup, where this change was already done in `release/3.0` but didn't make it to `master`. This PR is essentially a port of https://github.com/dotnet/core-setup/pull/7372.

The implementation in windowsdesktop is slightly different (simpler!) than it was in core-setup due to the repo split. This uses a downloaded targeting pack (ref package) to get the platform manifest, rather than a project-to-project reference. Similar to PR https://github.com/dotnet/windowsdesktop/pull/72.

This PR incorporates a fix for a typo in the core-setup/3.0 implementation: https://github.com/dotnet/core-setup/pull/8571.

To avoid merge conflicts, the new dependencies are in separate sections in `eng/Version.Details.xml` and `eng/Versions.props`. I'll sort them into the proper order along with fixing up the versions in my merge commit.