### PR TITLE
Sort new compatibility package dependencies into version props/details

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -37,6 +37,10 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>15e1ea023d2818b6083a61c7447a720ff3779482</Sha>
     </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19527.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>17c14aa2b50cfb5920d03ea8835c9a4932b5359c</Sha>
+    </Dependency>
     <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19528.12">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>15e1ea023d2818b6083a61c7447a720ff3779482</Sha>
@@ -56,6 +60,10 @@
     <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19528.12">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>15e1ea023d2818b6083a61c7447a720ff3779482</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Pipes.AccessControl" Version="4.5.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
     </Dependency>
     <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19528.12">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -128,19 +136,6 @@
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19462.5" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>2718e02209b325d3d188cb529c85a9fba94557d9</Sha>
-    </Dependency>
-    <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19527.5">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>17c14aa2b50cfb5920d03ea8835c9a4932b5359c</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19527.5">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>17c14aa2b50cfb5920d03ea8835c9a4932b5359c</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Pipes.AccessControl" Version="4.5.1">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,16 +37,19 @@
     <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha.1.19528.12</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha.1.19528.12</MicrosoftNETCoreTargetsPackageVersion>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>5.0.0-alpha.1.19528.12</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha.1.19527.5</MicrosoftWin32RegistryAccessControlVersion>
     <MicrosoftWin32RegistryVersion>5.0.0-alpha.1.19528.12</MicrosoftWin32RegistryVersion>
     <MicrosoftWin32SystemEventsVersion>5.0.0-alpha.1.19528.12</MicrosoftWin32SystemEventsVersion>
     <MicrosoftWindowsCompatibilityPackageVersion>5.0.0-alpha.1.19528.12</MicrosoftWindowsCompatibilityPackageVersion>
     <SystemCodeDomVersion>5.0.0-alpha.1.19528.12</SystemCodeDomVersion>
     <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha.1.19528.12</SystemConfigurationConfigurationManagerVersion>
     <SystemDiagnosticsEventLogVersion>5.0.0-alpha.1.19528.12</SystemDiagnosticsEventLogVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-alpha.1.19527.5</SystemDiagnosticsPerformanceCounterVersion>
     <SystemDirectoryServicesVersion>5.0.0-alpha.1.19528.12</SystemDirectoryServicesVersion>
     <SystemDrawingCommonVersion>5.0.0-alpha.1.19528.12</SystemDrawingCommonVersion>
     <SystemIOFileSystemAccessControlVersion>5.0.0-alpha.1.19528.12</SystemIOFileSystemAccessControlVersion>
     <SystemIOPackagingVersion>5.0.0-alpha.1.19528.12</SystemIOPackagingVersion>
+    <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
     <SystemResourcesExtensionsPackageVersion>5.0.0-alpha.1.19528.12</SystemResourcesExtensionsPackageVersion>
     <SystemSecurityAccessControlVersion>5.0.0-alpha.1.19528.12</SystemSecurityAccessControlVersion>
     <SystemSecurityCryptographyCngVersion>5.0.0-alpha.1.19528.12</SystemSecurityCryptographyCngVersion>
@@ -55,8 +58,8 @@
     <SystemSecurityCryptographyXmlVersion>5.0.0-alpha.1.19528.12</SystemSecurityCryptographyXmlVersion>
     <SystemSecurityPermissionsVersion>5.0.0-alpha.1.19528.12</SystemSecurityPermissionsVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha.1.19528.12</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextJsonVersion>5.0.0-alpha.1.19528.12</SystemTextJsonVersion>
     <SystemTextEncodingsWebVersion>5.0.0-alpha.1.19528.12</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>5.0.0-alpha.1.19528.12</SystemTextJsonVersion>
     <SystemThreadingAccessControlVersion>5.0.0-alpha.1.19528.12</SystemThreadingAccessControlVersion>
     <SystemWindowsExtensionsPackageVersion>5.0.0-alpha.1.19528.12</SystemWindowsExtensionsPackageVersion>
     <!-- standard -->
@@ -79,10 +82,6 @@
     <NugetPackagingPackageVersion>4.9.4</NugetPackagingPackageVersion>
     <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
-    <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
-    <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha.1.19527.5</MicrosoftWin32RegistryAccessControlVersion>
-    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-alpha.1.19527.5</SystemDiagnosticsPerformanceCounterVersion>
-    <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>


### PR DESCRIPTION
This was marked in a `TODO` for https://github.com/dotnet/windowsdesktop/pull/127, but I forgot to do it while merging the PR.

(`System.IO.FileSystem.AccessControl` was already in the list of dependencies so I simply removed the duplicate.)

/cc @MichaelSimons 