### PR TITLE
Add servicing build targeting pack skip config

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,9 +28,6 @@
     * Do not delete these lines to disable the package build. When PatchVersion is incremented at
       the beginning of the next servicing release, the package automatically stops building because
       the version no longer matches.
-
-    * These items also keep track of the last time each package was patched, enabling source-build
-      to produce the correct old version number using current sources.
   -->
   <ItemGroup Condition="'$(StabilizePackageVersion)' == 'true'">
     <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,23 @@
     <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
     <NETCoreAppFramework>netcoreapp$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
   </PropertyGroup>
+  <!--
+    Servicing build settings.
+
+    * To enable a package build for the current patch release, set PatchVersion to match the current
+      patch version of that package. (major.minor.patch)
+
+    * Do not delete these lines to disable the package build. When PatchVersion is incremented at
+      the beginning of the next servicing release, the package automatically stops building because
+      the version no longer matches.
+
+    * These items also keep track of the last time each package was patched, enabling source-build
+      to produce the correct old version number using current sources.
+  -->
+  <ItemGroup Condition="'$(StabilizePackageVersion)' == 'true'">
+    <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18619.4</MicrosoftDotNetMaestroTasksVersion>
   </PropertyGroup>

--- a/src/windowsdesktop/tests/WindowsDesktopNupkgTests.cs
+++ b/src/windowsdesktop/tests/WindowsDesktopNupkgTests.cs
@@ -25,7 +25,11 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             {
                 if (CurrentRidShouldCreateNupkg)
                 {
-                    Assert.NotNull(tester);
+                    // Allow no targeting pack for servicing builds.
+                    if (tester == null)
+                    {
+                        return;
+                    }
 
                     tester.IsTargetingPackForPlatform();
                     tester.HasOnlyTheseDataFiles(

--- a/src/windowsdesktop/tests/WindowsDesktopNupkgTests.cs
+++ b/src/windowsdesktop/tests/WindowsDesktopNupkgTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             {
                 if (CurrentRidShouldCreateNupkg)
                 {
-                    // Allow no targeting pack for servicing builds.
+                    // Allow no targeting pack for servicing builds. This is a minor test gap: https://github.com/dotnet/core-setup/issues/8830
                     if (tester == null)
                     {
                         return;


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/8735. Uses https://github.com/dotnet/arcade/pull/4318.

This sets up the WindowsDesktop targeting pack to only get built in stable builds if there's an intentional patch release. For 3.0/3.1, this is being done in Core-Setup:

3.0: https://github.com/dotnet/core-setup/pull/8827
3.1: https://github.com/dotnet/core-setup/pull/8828