### PR TITLE
Add classification for Microsoft.VisualBasic.dll

### DIFF
--- a/pkg/windowsdesktop/pkg/Directory.Build.props
+++ b/pkg/windowsdesktop/pkg/Directory.Build.props
@@ -20,6 +20,7 @@
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="Accessibility.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="Microsoft.VisualBasic.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="Microsoft.Win32.Registry.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.Registry.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.SystemEvents.dll" Profile="WindowsForms;WPF" />
@@ -70,6 +71,7 @@
     <FrameworkListFileClass Include="WindowsBase.dll" Profile="WPF" />
     <FrameworkListFileClass Include="WindowsFormsIntegration.dll" />
   </ItemGroup>
+  
 
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup>


### PR DESCRIPTION
- Add classification for M.VB.dll
- Ignore M.VB.Forms.dll during ref-checks.

/cc @dagood @AdamYoblick @rladuca 