### PR TITLE
Update Directory.Build.props

### DIFF
--- a/pkg/windowsdesktop/pkg/Directory.Build.props
+++ b/pkg/windowsdesktop/pkg/Directory.Build.props
@@ -62,6 +62,7 @@
     <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Input.Manipulations.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Windows.Presentation.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Xaml.dll" Profile="WPF" />


### PR DESCRIPTION
Windows Forms solution has been restructured and now has a new assembly System.Windows.Forms.Primitives.dll.
See https://github.com/dotnet/winforms/pull/2518 for more details.