### PR TITLE
Import WinForms references from transport package

### DIFF
--- a/pkg/windowsdesktop/pkg/Directory.Build.props
+++ b/pkg/windowsdesktop/pkg/Directory.Build.props
@@ -18,13 +18,44 @@
     <GeneratePkg>false</GeneratePkg>
   </PropertyGroup>
 
+  <!-- 
+    shared concerns, these shouldn't generally change
+    for profile information refere to https://github.com/dotnet/cli/issues/10536#issuecomment-488871926
+    -->
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="Accessibility.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="Microsoft.VisualBasic.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="Microsoft.VisualBasic.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="Microsoft.Win32.Registry.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.Registry.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.SystemEvents.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.CodeDom.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Configuration.ConfigurationManager.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Diagnostics.EventLog.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Diagnostics.PerformanceCounter.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.DirectoryServices.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.IO.FileSystem.AccessControl.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.IO.Packaging.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.IO.Pipes.AccessControl.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Resources.Extensions.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.AccessControl.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.Cryptography.Cng.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.Cryptography.Pkcs.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.Cryptography.ProtectedData.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.Cryptography.Xml.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.Principal.Windows.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Windows.Extensions.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="WindowsFormsIntegration.dll" />
+  </ItemGroup>
+
+  <!-- 
+    Windows Forms specific references
+    see: https://github.com/dotnet/winforms/pull/2707/commits/50a5258f7039dc81d99b1c3896a94c578387a3be
+    -->
+  <Import Project="$(NUGET_PACKAGES)\Microsoft.Private.Winforms\$(MicrosoftPrivateWinformsVersion)\FrameworkListFiles.props" />
+
+  <!-- WPF specific references -->
+  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="PresentationCore.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.Aero.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.Aero2.dll" Profile="WPF" />
@@ -35,33 +66,8 @@
     <FrameworkListFileClass Include="PresentationFramework.Royale.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationUI.dll" Profile="WPF" />
     <FrameworkListFileClass Include="ReachFramework.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="System.CodeDom.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Configuration.ConfigurationManager.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Design.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Diagnostics.EventLog.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Diagnostics.PerformanceCounter.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.DirectoryServices.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Drawing.Common.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Drawing.Design.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Drawing.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.IO.FileSystem.AccessControl.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.IO.Packaging.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.IO.Pipes.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Printing.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="System.Resources.Extensions.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.AccessControl.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.Cryptography.Cng.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.Cryptography.Pkcs.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.Cryptography.ProtectedData.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.Cryptography.Xml.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.Principal.Windows.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="System.Windows.Extensions.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Input.Manipulations.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Windows.Presentation.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Xaml.dll" Profile="WPF" />
@@ -70,9 +76,7 @@
     <FrameworkListFileClass Include="UIAutomationProvider.dll" Profile="WPF" />
     <FrameworkListFileClass Include="UIAutomationTypes.dll" Profile="WPF" />
     <FrameworkListFileClass Include="WindowsBase.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="WindowsFormsIntegration.dll" />
   </ItemGroup>
-  
 
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup>


### PR DESCRIPTION
As per https://github.com/dotnet/windowsdesktop/pull/362#issuecomment-571654136 Windows Forms will provide its list of references in own transport package, reduce x-repo maintenance overhead.

The original references separated into 3 distinct groups - shared, Windows Forms and WPF.
* The shared group is a x-cutting concerns, and should not generally change.
* The other groups (Windows Forms and WPF) are specific for each tech stack, and thus should be managed by each respective team, and shipped via the stack's transport packages.