### PR TITLE
Fix Microsoft.NETCore.App version in runtimeconfig

### DIFF
--- a/pkg/windowsdesktop/Directory.Build.props
+++ b/pkg/windowsdesktop/Directory.Build.props
@@ -28,6 +28,9 @@
       runtimes\win-x86\lib\netcoreapp3.0\System.Printing.dll
     -->
     <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
+
+    <!-- Generate the runtimeconfig with the correct Microsoft.NETCore.App version. -->
+    <MicrosoftNETCoreAppRuntimeConfigVersion>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreAppRuntimeConfigVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Partial fix for https://github.com/dotnet/windowsdesktop/issues/368. It will activate once this repo gets an Arcade update with https://github.com/dotnet/arcade/pull/4620 to support `MicrosoftNETCoreAppRuntimeConfigVersion`. Tested via `/p:DotNetBuildTasksSharedFrameworkMSBuildDir=C:\git\arcade\src\Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk\targets/`.