### PR TITLE
Add build skip functionality for servicing builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,25 @@
     <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
     <NETCoreAppFramework>netcoreapp$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
   </PropertyGroup>
+
+  <!--
+    Servicing build settings for setup packages. Instructions:
+
+    * To enable a package build for the current patch release, set PatchVersion to match the current
+      patch version of that package. ("major.minor.patch".) This is normally the same as
+      PatchVersion above.
+    * When the PatchVersion property above is incremented at the beginning of the next servicing
+      release, all packages listed below automatically stop building because the property no longer
+      matches the metadata. (Do not delete the items!)
+
+    If the PatchVersion below is never changed from '0', the package will build in the 'master'
+    branch, and during a forked RTM release ("X.Y.0"). It will stop building for "X.Y.1" unless
+    manually enabled by updating the metadata.
+  -->
+  <ItemGroup>
+    <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18619.4</MicrosoftDotNetMaestroTasksVersion>
   </PropertyGroup>

--- a/src/windowsdesktop/tests/WindowsDesktopNupkgTests.cs
+++ b/src/windowsdesktop/tests/WindowsDesktopNupkgTests.cs
@@ -25,7 +25,12 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             {
                 if (CurrentRidShouldCreateNupkg)
                 {
-                    Assert.NotNull(tester);
+                    // Allow no targeting pack in case this is a servicing build.
+                    // This condition should be tightened: https://github.com/dotnet/core-setup/issues/8830
+                    if (tester == null)
+                    {
+                        return;
+                    }
 
                     tester.IsTargetingPackForPlatform();
                     tester.HasOnlyTheseDataFiles(


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/2291 to WindowsDesktop. Fixes https://github.com/dotnet/windowsdesktop/issues/250.

In short, this will make it so that once we build 5.0.0, we will build a 5.0.0 targeting pack, but we won't build a 5.0.1+ targeting pack unless specified.