### PR TITLE
Add channel for '.NET 5 Preview 1'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,10 @@ variables:
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
 
+  # Fill in missing channel name variables.
+  - name: Net_5_Preview1_Channel_Id
+    value: 737
+
   # Produce test-signed build for PR and Public builds
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
     - name: SignType
@@ -91,6 +95,13 @@ stages:
           name: .NET Core 5 Dev
           bar: NetCore_5_Dev_Channel_Id
           storage: master
+          public: true
+
+      - dependsOn: Net5_Preview1_Publish
+        channel:
+          name: .NET 5 Preview 1
+          bar: Net_5_Preview1_Channel_Id
+          storage: release/5.0-preview1
           public: true
 
       - dependsOn: General_Testing_Publish


### PR DESCRIPTION
Add a channel mapping for new 5p1 channel. Adding/removing channels are breaking changes for dotnet/windowsdesktop until https://github.com/dotnet/core-setup/pull/8426 and associated PRs are ported to dotnet/windowsdesktop. /cc @mmitche 

I queued and canceled a very basic test build at https://dev.azure.com/dnceng/internal/_build/results?buildId=530465&view=results to see if template is valid.