### PR TITLE
Remove CPD to Microsoft.Private.Winforms temporarily

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,80 +2,80 @@
 <Dependencies>
   <ProductDependencies>
     <!-- <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!--
         Always ships a well-known version of System.IO.Pipes.AccessControl
@@ -87,61 +87,61 @@
       <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" >
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19564.1">
       <Uri>https://github.com/dotnet/standard</Uri>
@@ -149,27 +149,27 @@
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19513.3" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19513.3" >
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19564.1">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>b415b57a15b0c6ba77e63df901823bb46b8aafda</Sha>
+      <Sha>a9f3fc16483eecfc47fb79c362811d870be02249</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-preview.2.20154.1" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>a6624b38ba4d4609f69cfcb98add0edb058bfe9a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="5.0.0-preview.2.20154.3">
+    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="5.0.0-preview.2.20154.4">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>04d5165d8e0896797988bafd588ccc4a8391ce19</Sha>
+      <Sha>f1e76eeb102eade063eebfe3b3300d3b4e8c4c27</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" >
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha.1.19564.1">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>4ace84dbf94128b4825c76cdd09b46dba7473478</Sha>
+      <Sha>c77948d92a2f950140f09384f057cb893ec3955a</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" >
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha.1.19564.1">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>4ace84dbf94128b4825c76cdd09b46dba7473478</Sha>
+      <Sha>c77948d92a2f950140f09384f057cb893ec3955a</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,78 +3,78 @@
   <ProductDependencies>
     <!-- <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
     <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!--
@@ -88,59 +88,59 @@
     </Dependency>
     <!-- <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
     <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
     <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19564.1">
@@ -150,7 +150,7 @@
     <!-- <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19513.3" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
     <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19564.1">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>a9f3fc16483eecfc47fb79c362811d870be02249</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-preview.2.20154.1" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
@@ -163,12 +163,12 @@
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha.1.19564.1">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c77948d92a2f950140f09384f057cb893ec3955a</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha.1.19564.1">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c77948d92a2f950140f09384f057cb893ec3955a</Sha>
     </Dependency>
   </ProductDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,14 +2,14 @@
 <Dependencies>
   <ProductDependencies>
     <!-- <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha.1.19563.6">
@@ -17,65 +17,65 @@
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.CodeDom" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!--
         Always ships a well-known version of System.IO.Pipes.AccessControl
@@ -87,61 +87,61 @@
       <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Text.Json" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19564.1">
       <Uri>https://github.com/dotnet/standard</Uri>
@@ -153,23 +153,23 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>a9f3fc16483eecfc47fb79c362811d870be02249</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-preview.2.20154.1" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
+    <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-preview.1.20120.6" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>a6624b38ba4d4609f69cfcb98add0edb058bfe9a</Sha>
+      <Sha>d542887a907b98757a359078c3b4c25bf01b6837</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="5.0.0-preview.2.20154.4">
+    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="5.0.0-preview.1.20127.4">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>f1e76eeb102eade063eebfe3b3300d3b4e8c4c27</Sha>
+      <Sha>efb8416d6de753c84030444d926bf2661346a2b7</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha.1.19564.1">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>c77948d92a2f950140f09384f057cb893ec3955a</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha.1.19564.1">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>c77948d92a2f950140f09384f057cb893ec3955a</Sha>
+      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,80 +2,80 @@
 <Dependencies>
   <ProductDependencies>
     <!-- <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
     <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.CodeDom" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!--
         Always ships a well-known version of System.IO.Pipes.AccessControl
@@ -87,61 +87,61 @@
       <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
  -->
-    <Dependency Name="System.Text.Json" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <!-- <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.1.20120.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.19563.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19564.1">
       <Uri>https://github.com/dotnet/standard</Uri>
@@ -153,23 +153,23 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>a9f3fc16483eecfc47fb79c362811d870be02249</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-preview.1.20120.6" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
+    <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-preview.2.20154.1" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>d542887a907b98757a359078c3b4c25bf01b6837</Sha>
+      <Sha>a6624b38ba4d4609f69cfcb98add0edb058bfe9a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="5.0.0-preview.1.20127.4">
+    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="5.0.0-preview.2.20154.4">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>efb8416d6de753c84030444d926bf2661346a2b7</Sha>
+      <Sha>f1e76eeb102eade063eebfe3b3300d3b4e8c4c27</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-preview.1.20120.5">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-preview.2.20154.3">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+      <Sha>f0f33999dea0c1188b30c5e2705d3d3217aeae67</Sha>
     </Dependency>
     <!-- <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-preview.1.20120.5">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-preview.2.20154.3">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+      <Sha>f0f33999dea0c1188b30c5e2705d3d3217aeae67</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,63 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+ -->
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
@@ -70,47 +86,60 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
     </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+ -->
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+ -->
+    <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" >
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8d21b79b924d29088dbde46d42737a657d466b5e</Sha>
     </Dependency>
@@ -118,7 +147,9 @@
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>cfe95a23647c7de1fe1a349343115bd7720d6949</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19513.3" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19513.3" CoherentParentDependency="Microsoft.Private.Winforms">
+ -->
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19513.3" >
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>b415b57a15b0c6ba77e63df901823bb46b8aafda</Sha>
     </Dependency>
@@ -130,11 +161,13 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>04d5165d8e0896797988bafd588ccc4a8391ce19</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" >
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>4ace84dbf94128b4825c76cdd09b46dba7473478</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <!-- <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" >
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>4ace84dbf94128b4825c76cdd09b46dba7473478</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,45 +46,45 @@
     <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20153.1</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20153.1</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- core-setup -->
-    <MicrosoftNETCoreAppRefVersion>5.0.0-preview.1.20120.5</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-preview.1.20120.5</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCoreAppRefVersion>5.0.0-preview.2.20154.3</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-preview.2.20154.3</MicrosoftNETCoreAppRuntimewinx64Version>
     <!-- corefx -->
-    <MicrosoftNETCorePlatformsVersion>5.0.0-preview.1.20120.5</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNETCoreTargetsVersion>5.0.0-preview.1.20120.5</MicrosoftNETCoreTargetsVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCoreTargetsVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCoreTargetsVersion>
     <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha.1.19563.6</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha.1.19527.5</MicrosoftWin32RegistryAccessControlVersion>
-    <MicrosoftWin32RegistryVersion>5.0.0-preview.1.20120.5</MicrosoftWin32RegistryVersion>
-    <MicrosoftWin32SystemEventsVersion>5.0.0-preview.1.20120.5</MicrosoftWin32SystemEventsVersion>
-    <MicrosoftWindowsCompatibilityVersion>5.0.0-preview.1.20120.5</MicrosoftWindowsCompatibilityVersion>
-    <SystemCodeDomVersion>5.0.0-preview.1.20120.5</SystemCodeDomVersion>
-    <SystemConfigurationConfigurationManagerVersion>5.0.0-preview.1.20120.5</SystemConfigurationConfigurationManagerVersion>
-    <SystemDiagnosticsEventLogVersion>5.0.0-preview.1.20120.5</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-preview.1.20120.5</SystemDiagnosticsPerformanceCounterVersion>
-    <SystemDirectoryServicesVersion>5.0.0-preview.1.20120.5</SystemDirectoryServicesVersion>
-    <SystemDrawingCommonVersion>5.0.0-preview.1.20120.5</SystemDrawingCommonVersion>
-    <SystemIOFileSystemAccessControlVersion>5.0.0-preview.1.20120.5</SystemIOFileSystemAccessControlVersion>
-    <SystemIOPackagingVersion>5.0.0-preview.1.20120.5</SystemIOPackagingVersion>
+    <MicrosoftWin32RegistryVersion>5.0.0-alpha.1.19563.6</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha.1.19563.6</MicrosoftWin32SystemEventsVersion>
+    <MicrosoftWindowsCompatibilityVersion>5.0.0-alpha.1.19563.6</MicrosoftWindowsCompatibilityVersion>
+    <SystemCodeDomVersion>5.0.0-alpha.1.19563.6</SystemCodeDomVersion>
+    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha.1.19563.6</SystemConfigurationConfigurationManagerVersion>
+    <SystemDiagnosticsEventLogVersion>5.0.0-alpha.1.19563.6</SystemDiagnosticsEventLogVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-alpha.1.19563.6</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemDirectoryServicesVersion>5.0.0-alpha.1.19563.6</SystemDirectoryServicesVersion>
+    <SystemDrawingCommonVersion>5.0.0-alpha.1.19563.6</SystemDrawingCommonVersion>
+    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha.1.19563.6</SystemIOFileSystemAccessControlVersion>
+    <SystemIOPackagingVersion>5.0.0-alpha.1.19563.6</SystemIOPackagingVersion>
     <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
-    <SystemResourcesExtensionsVersion>5.0.0-preview.1.20120.5</SystemResourcesExtensionsVersion>
-    <SystemSecurityAccessControlVersion>5.0.0-preview.1.20120.5</SystemSecurityAccessControlVersion>
-    <SystemSecurityCryptographyCngVersion>5.0.0-preview.1.20120.5</SystemSecurityCryptographyCngVersion>
-    <SystemSecurityCryptographyPkcsVersion>5.0.0-preview.1.20120.5</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-preview.1.20120.5</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlVersion>5.0.0-preview.1.20120.5</SystemSecurityCryptographyXmlVersion>
-    <SystemSecurityPermissionsVersion>5.0.0-preview.1.20120.5</SystemSecurityPermissionsVersion>
-    <SystemSecurityPrincipalWindowsVersion>5.0.0-preview.1.20120.5</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextEncodingsWebVersion>5.0.0-preview.1.20120.5</SystemTextEncodingsWebVersion>
-    <SystemTextJsonVersion>5.0.0-preview.1.20120.5</SystemTextJsonVersion>
-    <SystemThreadingAccessControlVersion>5.0.0-preview.1.20120.5</SystemThreadingAccessControlVersion>
-    <SystemWindowsExtensionsVersion>5.0.0-preview.1.20120.5</SystemWindowsExtensionsVersion>
+    <SystemResourcesExtensionsVersion>5.0.0-alpha.1.19563.6</SystemResourcesExtensionsVersion>
+    <SystemSecurityAccessControlVersion>5.0.0-alpha.1.19563.6</SystemSecurityAccessControlVersion>
+    <SystemSecurityCryptographyCngVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyCngVersion>
+    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyProtectedDataVersion>
+    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityPermissionsVersion>5.0.0-alpha.1.19563.6</SystemSecurityPermissionsVersion>
+    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha.1.19563.6</SystemSecurityPrincipalWindowsVersion>
+    <SystemTextEncodingsWebVersion>5.0.0-alpha.1.19563.6</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>5.0.0-alpha.1.19563.6</SystemTextJsonVersion>
+    <SystemThreadingAccessControlVersion>5.0.0-alpha.1.19563.6</SystemThreadingAccessControlVersion>
+    <SystemWindowsExtensionsVersion>5.0.0-alpha.1.19563.6</SystemWindowsExtensionsVersion>
     <!-- standard -->
     <NETStandardLibraryVersion>2.2.0-prerelease.19564.1</NETStandardLibraryVersion>
     <!-- coreclr -->
     <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19564.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <!-- winforms -->
-    <MicrosoftPrivateWinformsVersion>5.0.0-preview.1.20120.6</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>5.0.0-preview.2.20154.1</MicrosoftPrivateWinformsVersion>
     <!-- wpf -->
-    <MicrosoftDotNetWpfGitHubVersion>5.0.0-preview.1.20127.4</MicrosoftDotNetWpfGitHubVersion>
+    <MicrosoftDotNetWpfGitHubVersion>5.0.0-preview.2.20154.4</MicrosoftDotNetWpfGitHubVersion>
     <!-- Not auto-updated. -->
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,45 +46,45 @@
     <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20153.1</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20153.1</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- core-setup -->
-    <MicrosoftNETCoreAppRefVersion>5.0.0-alpha.1.19564.1</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-alpha.1.19564.1</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCoreAppRefVersion>5.0.0-preview.1.20120.5</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-preview.1.20120.5</MicrosoftNETCoreAppRuntimewinx64Version>
     <!-- corefx -->
-    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNETCoreTargetsVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCoreTargetsVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0-preview.1.20120.5</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCoreTargetsVersion>5.0.0-preview.1.20120.5</MicrosoftNETCoreTargetsVersion>
     <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha.1.19563.6</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha.1.19527.5</MicrosoftWin32RegistryAccessControlVersion>
-    <MicrosoftWin32RegistryVersion>5.0.0-alpha.1.19563.6</MicrosoftWin32RegistryVersion>
-    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha.1.19563.6</MicrosoftWin32SystemEventsVersion>
-    <MicrosoftWindowsCompatibilityVersion>5.0.0-alpha.1.19563.6</MicrosoftWindowsCompatibilityVersion>
-    <SystemCodeDomVersion>5.0.0-alpha.1.19563.6</SystemCodeDomVersion>
-    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha.1.19563.6</SystemConfigurationConfigurationManagerVersion>
-    <SystemDiagnosticsEventLogVersion>5.0.0-alpha.1.19563.6</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-alpha.1.19563.6</SystemDiagnosticsPerformanceCounterVersion>
-    <SystemDirectoryServicesVersion>5.0.0-alpha.1.19563.6</SystemDirectoryServicesVersion>
-    <SystemDrawingCommonVersion>5.0.0-alpha.1.19563.6</SystemDrawingCommonVersion>
-    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha.1.19563.6</SystemIOFileSystemAccessControlVersion>
-    <SystemIOPackagingVersion>5.0.0-alpha.1.19563.6</SystemIOPackagingVersion>
+    <MicrosoftWin32RegistryVersion>5.0.0-preview.1.20120.5</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32SystemEventsVersion>5.0.0-preview.1.20120.5</MicrosoftWin32SystemEventsVersion>
+    <MicrosoftWindowsCompatibilityVersion>5.0.0-preview.1.20120.5</MicrosoftWindowsCompatibilityVersion>
+    <SystemCodeDomVersion>5.0.0-preview.1.20120.5</SystemCodeDomVersion>
+    <SystemConfigurationConfigurationManagerVersion>5.0.0-preview.1.20120.5</SystemConfigurationConfigurationManagerVersion>
+    <SystemDiagnosticsEventLogVersion>5.0.0-preview.1.20120.5</SystemDiagnosticsEventLogVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-preview.1.20120.5</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemDirectoryServicesVersion>5.0.0-preview.1.20120.5</SystemDirectoryServicesVersion>
+    <SystemDrawingCommonVersion>5.0.0-preview.1.20120.5</SystemDrawingCommonVersion>
+    <SystemIOFileSystemAccessControlVersion>5.0.0-preview.1.20120.5</SystemIOFileSystemAccessControlVersion>
+    <SystemIOPackagingVersion>5.0.0-preview.1.20120.5</SystemIOPackagingVersion>
     <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
-    <SystemResourcesExtensionsVersion>5.0.0-alpha.1.19563.6</SystemResourcesExtensionsVersion>
-    <SystemSecurityAccessControlVersion>5.0.0-alpha.1.19563.6</SystemSecurityAccessControlVersion>
-    <SystemSecurityCryptographyCngVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyCngVersion>
-    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyXmlVersion>
-    <SystemSecurityPermissionsVersion>5.0.0-alpha.1.19563.6</SystemSecurityPermissionsVersion>
-    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha.1.19563.6</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextEncodingsWebVersion>5.0.0-alpha.1.19563.6</SystemTextEncodingsWebVersion>
-    <SystemTextJsonVersion>5.0.0-alpha.1.19563.6</SystemTextJsonVersion>
-    <SystemThreadingAccessControlVersion>5.0.0-alpha.1.19563.6</SystemThreadingAccessControlVersion>
-    <SystemWindowsExtensionsVersion>5.0.0-alpha.1.19563.6</SystemWindowsExtensionsVersion>
+    <SystemResourcesExtensionsVersion>5.0.0-preview.1.20120.5</SystemResourcesExtensionsVersion>
+    <SystemSecurityAccessControlVersion>5.0.0-preview.1.20120.5</SystemSecurityAccessControlVersion>
+    <SystemSecurityCryptographyCngVersion>5.0.0-preview.1.20120.5</SystemSecurityCryptographyCngVersion>
+    <SystemSecurityCryptographyPkcsVersion>5.0.0-preview.1.20120.5</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-preview.1.20120.5</SystemSecurityCryptographyProtectedDataVersion>
+    <SystemSecurityCryptographyXmlVersion>5.0.0-preview.1.20120.5</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityPermissionsVersion>5.0.0-preview.1.20120.5</SystemSecurityPermissionsVersion>
+    <SystemSecurityPrincipalWindowsVersion>5.0.0-preview.1.20120.5</SystemSecurityPrincipalWindowsVersion>
+    <SystemTextEncodingsWebVersion>5.0.0-preview.1.20120.5</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>5.0.0-preview.1.20120.5</SystemTextJsonVersion>
+    <SystemThreadingAccessControlVersion>5.0.0-preview.1.20120.5</SystemThreadingAccessControlVersion>
+    <SystemWindowsExtensionsVersion>5.0.0-preview.1.20120.5</SystemWindowsExtensionsVersion>
     <!-- standard -->
     <NETStandardLibraryVersion>2.2.0-prerelease.19564.1</NETStandardLibraryVersion>
     <!-- coreclr -->
     <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19564.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <!-- winforms -->
-    <MicrosoftPrivateWinformsVersion>5.0.0-preview.2.20154.1</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>5.0.0-preview.1.20120.6</MicrosoftPrivateWinformsVersion>
     <!-- wpf -->
-    <MicrosoftDotNetWpfGitHubVersion>5.0.0-preview.2.20154.4</MicrosoftDotNetWpfGitHubVersion>
+    <MicrosoftDotNetWpfGitHubVersion>5.0.0-preview.1.20127.4</MicrosoftDotNetWpfGitHubVersion>
     <!-- Not auto-updated. -->
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,45 +46,45 @@
     <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20153.1</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20153.1</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- core-setup -->
-    <MicrosoftNETCoreAppRefVersion>5.0.0-alpha1.19514.1</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-alpha1.19514.1</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCoreAppRefVersion>5.0.0-alpha.1.19564.1</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-alpha.1.19564.1</MicrosoftNETCoreAppRuntimewinx64Version>
     <!-- corefx -->
-    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha1.19512.1</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNETCoreTargetsVersion>5.0.0-alpha1.19512.1</MicrosoftNETCoreTargetsVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha1.19512.1</MicrosoftPrivateCoreFxNETCoreAppVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCoreTargetsVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCoreTargetsVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha.1.19563.6</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha.1.19527.5</MicrosoftWin32RegistryAccessControlVersion>
-    <MicrosoftWin32RegistryVersion>5.0.0-alpha1.19512.1</MicrosoftWin32RegistryVersion>
-    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha1.19512.1</MicrosoftWin32SystemEventsVersion>
-    <MicrosoftWindowsCompatibilityVersion>5.0.0-alpha1.19512.1</MicrosoftWindowsCompatibilityVersion>
-    <SystemCodeDomVersion>5.0.0-alpha1.19512.1</SystemCodeDomVersion>
-    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha1.19512.1</SystemConfigurationConfigurationManagerVersion>
-    <SystemDiagnosticsEventLogVersion>5.0.0-alpha1.19512.1</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-alpha1.19512.1</SystemDiagnosticsPerformanceCounterVersion>
-    <SystemDirectoryServicesVersion>5.0.0-alpha1.19512.1</SystemDirectoryServicesVersion>
-    <SystemDrawingCommonVersion>5.0.0-alpha1.19512.1</SystemDrawingCommonVersion>
-    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha1.19512.1</SystemIOFileSystemAccessControlVersion>
-    <SystemIOPackagingVersion>5.0.0-alpha1.19512.1</SystemIOPackagingVersion>
+    <MicrosoftWin32RegistryVersion>5.0.0-alpha.1.19563.6</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha.1.19563.6</MicrosoftWin32SystemEventsVersion>
+    <MicrosoftWindowsCompatibilityVersion>5.0.0-alpha.1.19563.6</MicrosoftWindowsCompatibilityVersion>
+    <SystemCodeDomVersion>5.0.0-alpha.1.19563.6</SystemCodeDomVersion>
+    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha.1.19563.6</SystemConfigurationConfigurationManagerVersion>
+    <SystemDiagnosticsEventLogVersion>5.0.0-alpha.1.19563.6</SystemDiagnosticsEventLogVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-alpha.1.19563.6</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemDirectoryServicesVersion>5.0.0-alpha.1.19563.6</SystemDirectoryServicesVersion>
+    <SystemDrawingCommonVersion>5.0.0-alpha.1.19563.6</SystemDrawingCommonVersion>
+    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha.1.19563.6</SystemIOFileSystemAccessControlVersion>
+    <SystemIOPackagingVersion>5.0.0-alpha.1.19563.6</SystemIOPackagingVersion>
     <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
-    <SystemResourcesExtensionsVersion>5.0.0-alpha1.19512.1</SystemResourcesExtensionsVersion>
-    <SystemSecurityAccessControlVersion>5.0.0-alpha1.19512.1</SystemSecurityAccessControlVersion>
-    <SystemSecurityCryptographyCngVersion>5.0.0-alpha1.19512.1</SystemSecurityCryptographyCngVersion>
-    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha1.19512.1</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha1.19512.1</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha1.19512.1</SystemSecurityCryptographyXmlVersion>
-    <SystemSecurityPermissionsVersion>5.0.0-alpha1.19512.1</SystemSecurityPermissionsVersion>
-    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha1.19512.1</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextEncodingsWebVersion>5.0.0-alpha1.19512.1</SystemTextEncodingsWebVersion>
-    <SystemTextJsonVersion>5.0.0-alpha1.19512.1</SystemTextJsonVersion>
-    <SystemThreadingAccessControlVersion>5.0.0-alpha1.19512.1</SystemThreadingAccessControlVersion>
-    <SystemWindowsExtensionsVersion>5.0.0-alpha1.19512.1</SystemWindowsExtensionsVersion>
+    <SystemResourcesExtensionsVersion>5.0.0-alpha.1.19563.6</SystemResourcesExtensionsVersion>
+    <SystemSecurityAccessControlVersion>5.0.0-alpha.1.19563.6</SystemSecurityAccessControlVersion>
+    <SystemSecurityCryptographyCngVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyCngVersion>
+    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyProtectedDataVersion>
+    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha.1.19563.6</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityPermissionsVersion>5.0.0-alpha.1.19563.6</SystemSecurityPermissionsVersion>
+    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha.1.19563.6</SystemSecurityPrincipalWindowsVersion>
+    <SystemTextEncodingsWebVersion>5.0.0-alpha.1.19563.6</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>5.0.0-alpha.1.19563.6</SystemTextJsonVersion>
+    <SystemThreadingAccessControlVersion>5.0.0-alpha.1.19563.6</SystemThreadingAccessControlVersion>
+    <SystemWindowsExtensionsVersion>5.0.0-alpha.1.19563.6</SystemWindowsExtensionsVersion>
     <!-- standard -->
     <NETStandardLibraryVersion>2.2.0-prerelease.19564.1</NETStandardLibraryVersion>
     <!-- coreclr -->
-    <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19513.3</MicrosoftNETCoreRuntimeCoreCLRVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19564.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <!-- winforms -->
     <MicrosoftPrivateWinformsVersion>5.0.0-preview.2.20154.1</MicrosoftPrivateWinformsVersion>
     <!-- wpf -->
-    <MicrosoftDotNetWpfGitHubVersion>5.0.0-preview.2.20154.3</MicrosoftDotNetWpfGitHubVersion>
+    <MicrosoftDotNetWpfGitHubVersion>5.0.0-preview.2.20154.4</MicrosoftDotNetWpfGitHubVersion>
     <!-- Not auto-updated. -->
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>


### PR DESCRIPTION
Porting https://github.com/dotnet/windowsdesktop/pull/534 to master. 

Removes CPD to` Microsoft.Private.Winforms` temporarily, until updated C++/CLI toolset becomes available (see related issues below). 

This will help ensure that WindowsDesktop apps (i.e., WPF and WinForms apps) built out of dotnet/windowsdesktop and targeting the *shared sdk* are able to find and load the runtime bundled with the SDK itself. 

The downside is that the runtime that is bundled with the SDK is *not* the runtime (i.e., the ref-assemblies corresponding to the runtime) that was used to build WinForms and WPF binaries. This is what the CPD (_CoherentParentDependency_) ensures happens correctly. 

Removing the CPD ensures that the _runtimeconfig.json_ embedded in the WindowsDesktop shared runtime points to the same runtime (`Microsoft.NetCore.App`) that is bundled with the SDK. 

In an ideal world, WinForms and WPF would build against the version of `Microsoft.NetCore.App` that will be eventually bundled into the SDK - and thus the CPD would continue to be retained in `dotnet/windowsdesktop` repo. Today, we are unable to ingest newer versions of `Microsoft.NetCore.App` due to tooling problems (see links/discussion below), so this workaround is being added. 

Related:
- https://github.com/dotnet/wpf/pull/2118
- https://github.com/dotnet/winforms/pull/2497
- https://github.com/dotnet/winforms/pull/2707

/cc @dotnet/wpf-developers, @mmitche, @wtgodbe, @RussKie , @AdamYoblick, @nguerrera, @dsplaisted, @ericstj, @tgani-msft, @jeffschwMSFT 

