### PR TITLE
Bring back CPD wrt Microsoft.Private.Winforms

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,79 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <!-- <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
- -->
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
@@ -86,60 +84,58 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
- -->
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms">
- -->
-    <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <!-- <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19512.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.19563.6">
+
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
@@ -147,9 +143,8 @@
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>cfe95a23647c7de1fe1a349343115bd7720d6949</Sha>
     </Dependency>
-    <!-- <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19513.3" CoherentParentDependency="Microsoft.Private.Winforms">
- -->
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19564.1">
+
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19564.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>a9f3fc16483eecfc47fb79c362811d870be02249</Sha>
     </Dependency>
@@ -161,13 +156,13 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>ed4e4556dc46e85efb5b2431fb1122fbf27542a0</Sha>
     </Dependency>
-    <!-- <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-preview.2.20154.3">
+
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-preview.2.20154.3" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f0f33999dea0c1188b30c5e2705d3d3217aeae67</Sha>
     </Dependency>
-    <!-- <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19514.1" CoherentParentDependency="Microsoft.Private.Winforms"> -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-preview.2.20154.3">
+
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-preview.2.20154.3" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f0f33999dea0c1188b30c5e2705d3d3217aeae67</Sha>
     </Dependency>


### PR DESCRIPTION
#579 removed CPD wrt Microsoft.Private.Winforms. Bring back this CPD in preparation of resuming ingestion of dotnet/runtime updates into dotnet/winforms -> dotnet/wpf -> dotnet/windowsdesktop

Versions have not been updated at this time to prevent version downgrades. 

/cc @dotnet/wpf-developers, @dotnet/dotnet-winforms 