### PR TITLE
Updated build.ps1 to use the correct MSBuild param for target arch

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -86,7 +86,7 @@ function Build {
   InitializeCustomToolset
 
   $bl = if ($binaryLog) { '/bl:' + (Join-Path $LogDir 'Build.binlog') } else { '' }
-  $platformArg = if ($platform) { "/p:Platform=$platform" } else { '' }
+  $platformArg = if ($platform) { "/p:TargetArchitecture=$platform" } else { '' }
 
   if ($projects) {
     # Re-assign properties to a new variable because PowerShell doesn't let us append properties directly for unclear reasons.


### PR DESCRIPTION
As seen in the Azure pipelines YAML file, `/p:TargetArchitecture` is the param that should be used when calling MSBuild

Fixes #760 