### PR TITLE
Set correct SharedFrameworkName property value

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,7 +65,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
+    <SharedFrameworkName>Microsoft.WindowsDesktop.App</SharedFrameworkName>
     <NETCoreAppFrameworkIdentifier>.NETCoreApp</NETCoreAppFrameworkIdentifier>
     <NETCoreAppFrameworkMoniker>$(NETCoreAppFrameworkIdentifier),Version=v$(NETCoreAppFrameworkVersion)</NETCoreAppFrameworkMoniker>
     <NETCoreAppFrameworkBrandName>.NET Core $(NETCoreAppFrameworkVersion)</NETCoreAppFrameworkBrandName>

--- a/pkg/windowsdesktop/Directory.Build.props
+++ b/pkg/windowsdesktop/Directory.Build.props
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ShortFrameworkName>windowsdesktop</ShortFrameworkName>
 
-    <FrameworkPackageName>Microsoft.WindowsDesktop.App</FrameworkPackageName>
+    <FrameworkPackageName>$(SharedFrameworkName)</FrameworkPackageName>
 
     <VSInsertionProductName>WindowsDesktop</VSInsertionProductName>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/windowsdesktop/issues/541

This change corrects the setup registry key name, from `SOFTWARE\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App`, to 
`SOFTWARE\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.WindowsDesktop.App`