### PR TITLE
[release/5.0-preview5] Fix repository url

### DIFF
--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -10,7 +10,7 @@
     <PackageDescriptionFile>$(MSBuildThisFileDirectory)descriptions.json</PackageDescriptionFile>
     <!-- This link should be updated for each release milestone, currently this points to 1.0.0 -->
     <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799417</ReleaseNotes>
-    <PackageProjectUrl>https://dot.net</PackageProjectUrl>
+    <ProjectUrl>https://dot.net</ProjectUrl>
     <RepositoryUrl>https://github.com/dotnet/windowsdesktop</RepositoryUrl>
 
     <!-- this repo doesn't currently use the index so don't force it to be in sync -->


### PR DESCRIPTION
Change accidentally leaked in from my attempts to fix the arcade update in p5