### PR TITLE
Remove references to the WinRT targeting pack

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,7 +93,6 @@
     <MicrosoftDotNetPlatformAbstractionsVersion>1.1.1</MicrosoftDotNetPlatformAbstractionsVersion>
     <NugetProjectModelVersion>4.9.4</NugetProjectModelVersion>
     <NugetPackagingVersion>4.9.4</NugetPackagingVersion>
-    <MicrosoftTargetingPackPrivateWinRTVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.7.0</MicrosoftDiaSymReaderNativeVersion>
   </PropertyGroup>
   <!--Package names-->
@@ -105,7 +104,6 @@
     <NETStandardLibraryPackage>NETStandard.Library</NETStandardLibraryPackage>
     <MicrosoftNETCoreRuntimeCoreCLRPackage>Microsoft.NETCore.Runtime.CoreCLR</MicrosoftNETCoreRuntimeCoreCLRPackage>
     <MicrosoftBclJsonSourcesPackage>Microsoft.Bcl.Json.Sources</MicrosoftBclJsonSourcesPackage>
-    <MicrosoftTargetingPackPrivateWinRTPackage>Microsoft.TargetingPack.Private.WinRT</MicrosoftTargetingPackPrivateWinRTPackage>
     <MicrosoftSymbolUploaderBuildTaskPackage>Microsoft.SymbolUploader.Build.Task</MicrosoftSymbolUploaderBuildTaskPackage>
   </PropertyGroup>
   <!-- Base runtime pack name (RID-less) for shared framework tooling. -->


### PR DESCRIPTION
None of the components reference the targeting pack and the Shared Framework SDK now allows it to be optional.

The crossgen that's incoming from dotnet/runtime via the winforms/wpf update no longer supports WinMDs, so we need to stop passing them.