### PR TITLE
[Preview 6] Ignore System.Runtime.InteropServices.WindowsRuntime reference

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.CodeDom" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
     <!--
         Always ships a well-known version of System.IO.Pipes.AccessControl
@@ -70,49 +70,49 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>7ee84596d92e178bce54c986df31ccc52479e772</Sha>
     </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Text.Json" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19564.1">
       <Uri>https://github.com/dotnet/standard</Uri>
@@ -122,21 +122,21 @@
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>d5bb8bf2437d447750cf0203dd55bb5160ff36b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-preview.6.20280.1" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
+    <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-preview.6.20306.1" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>8e716dc40cadaa16e322594d38709ed63e228302</Sha>
+      <Sha>81ba46e69bf930a9e963268ec13f5472f40eb06b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="5.0.0-preview.6.20305.3">
+    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="5.0.0-preview.6.20306.1">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>ef7b0fc77d89d735c10ccec8a5d7787fa0aa60ba</Sha>
+      <Sha>505af79f4f55e87e2eacef7cd75fece0f130f855</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-preview.6.20279.7" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-preview.6.20305.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>27dcce57c7fc4cfa6634f3f064edaa92f2f6eb83</Sha>
+      <Sha>4ba9ecaabd4d5c87c776a030eafdac0bae0512cf</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,45 +46,45 @@
     <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20280.1</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20280.1</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- core-setup -->
-    <MicrosoftNETCoreAppRefVersion>5.0.0-preview.6.20279.7</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-preview.6.20279.7</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCoreAppRefVersion>5.0.0-preview.6.20305.6</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-preview.6.20305.6</MicrosoftNETCoreAppRuntimewinx64Version>
     <!-- corefx -->
-    <MicrosoftNETCorePlatformsVersion>5.0.0-preview.6.20279.7</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNETCoreTargetsVersion>5.0.0-preview.6.20279.7</MicrosoftNETCoreTargetsVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0-preview.6.20305.6</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCoreTargetsVersion>5.0.0-preview.6.20305.6</MicrosoftNETCoreTargetsVersion>
     <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha.1.19563.6</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha.1.19527.5</MicrosoftWin32RegistryAccessControlVersion>
-    <MicrosoftWin32RegistryVersion>5.0.0-preview.6.20279.7</MicrosoftWin32RegistryVersion>
-    <MicrosoftWin32SystemEventsVersion>5.0.0-preview.6.20279.7</MicrosoftWin32SystemEventsVersion>
-    <MicrosoftWindowsCompatibilityVersion>5.0.0-preview.6.20279.7</MicrosoftWindowsCompatibilityVersion>
-    <SystemCodeDomVersion>5.0.0-preview.6.20279.7</SystemCodeDomVersion>
-    <SystemConfigurationConfigurationManagerVersion>5.0.0-preview.6.20279.7</SystemConfigurationConfigurationManagerVersion>
-    <SystemDiagnosticsEventLogVersion>5.0.0-preview.6.20279.7</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-preview.6.20279.7</SystemDiagnosticsPerformanceCounterVersion>
-    <SystemDirectoryServicesVersion>5.0.0-preview.6.20279.7</SystemDirectoryServicesVersion>
-    <SystemDrawingCommonVersion>5.0.0-preview.6.20279.7</SystemDrawingCommonVersion>
-    <SystemIOFileSystemAccessControlVersion>5.0.0-preview.6.20279.7</SystemIOFileSystemAccessControlVersion>
-    <SystemIOPackagingVersion>5.0.0-preview.6.20279.7</SystemIOPackagingVersion>
+    <MicrosoftWin32RegistryVersion>5.0.0-preview.6.20305.6</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32SystemEventsVersion>5.0.0-preview.6.20305.6</MicrosoftWin32SystemEventsVersion>
+    <MicrosoftWindowsCompatibilityVersion>5.0.0-preview.6.20305.6</MicrosoftWindowsCompatibilityVersion>
+    <SystemCodeDomVersion>5.0.0-preview.6.20305.6</SystemCodeDomVersion>
+    <SystemConfigurationConfigurationManagerVersion>5.0.0-preview.6.20305.6</SystemConfigurationConfigurationManagerVersion>
+    <SystemDiagnosticsEventLogVersion>5.0.0-preview.6.20305.6</SystemDiagnosticsEventLogVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>5.0.0-preview.6.20305.6</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemDirectoryServicesVersion>5.0.0-preview.6.20305.6</SystemDirectoryServicesVersion>
+    <SystemDrawingCommonVersion>5.0.0-preview.6.20305.6</SystemDrawingCommonVersion>
+    <SystemIOFileSystemAccessControlVersion>5.0.0-preview.6.20305.6</SystemIOFileSystemAccessControlVersion>
+    <SystemIOPackagingVersion>5.0.0-preview.6.20305.6</SystemIOPackagingVersion>
     <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
-    <SystemResourcesExtensionsVersion>5.0.0-preview.6.20279.7</SystemResourcesExtensionsVersion>
-    <SystemSecurityAccessControlVersion>5.0.0-preview.6.20279.7</SystemSecurityAccessControlVersion>
-    <SystemSecurityCryptographyCngVersion>5.0.0-preview.6.20279.7</SystemSecurityCryptographyCngVersion>
-    <SystemSecurityCryptographyPkcsVersion>5.0.0-preview.6.20279.7</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-preview.6.20279.7</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlVersion>5.0.0-preview.6.20279.7</SystemSecurityCryptographyXmlVersion>
-    <SystemSecurityPermissionsVersion>5.0.0-preview.6.20279.7</SystemSecurityPermissionsVersion>
-    <SystemSecurityPrincipalWindowsVersion>5.0.0-preview.6.20279.7</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextEncodingsWebVersion>5.0.0-preview.6.20279.7</SystemTextEncodingsWebVersion>
-    <SystemTextJsonVersion>5.0.0-preview.6.20279.7</SystemTextJsonVersion>
-    <SystemThreadingAccessControlVersion>5.0.0-preview.6.20279.7</SystemThreadingAccessControlVersion>
-    <SystemWindowsExtensionsVersion>5.0.0-preview.6.20279.7</SystemWindowsExtensionsVersion>
+    <SystemResourcesExtensionsVersion>5.0.0-preview.6.20305.6</SystemResourcesExtensionsVersion>
+    <SystemSecurityAccessControlVersion>5.0.0-preview.6.20305.6</SystemSecurityAccessControlVersion>
+    <SystemSecurityCryptographyCngVersion>5.0.0-preview.6.20305.6</SystemSecurityCryptographyCngVersion>
+    <SystemSecurityCryptographyPkcsVersion>5.0.0-preview.6.20305.6</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-preview.6.20305.6</SystemSecurityCryptographyProtectedDataVersion>
+    <SystemSecurityCryptographyXmlVersion>5.0.0-preview.6.20305.6</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityPermissionsVersion>5.0.0-preview.6.20305.6</SystemSecurityPermissionsVersion>
+    <SystemSecurityPrincipalWindowsVersion>5.0.0-preview.6.20305.6</SystemSecurityPrincipalWindowsVersion>
+    <SystemTextEncodingsWebVersion>5.0.0-preview.6.20305.6</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>5.0.0-preview.6.20305.6</SystemTextJsonVersion>
+    <SystemThreadingAccessControlVersion>5.0.0-preview.6.20305.6</SystemThreadingAccessControlVersion>
+    <SystemWindowsExtensionsVersion>5.0.0-preview.6.20305.6</SystemWindowsExtensionsVersion>
     <!-- standard -->
     <NETStandardLibraryVersion>2.2.0-prerelease.19564.1</NETStandardLibraryVersion>
     <!-- coreclr -->
     <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19562.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <!-- winforms -->
-    <MicrosoftPrivateWinformsVersion>5.0.0-preview.6.20280.1</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>5.0.0-preview.6.20306.1</MicrosoftPrivateWinformsVersion>
     <!-- wpf -->
-    <MicrosoftDotNetWpfGitHubVersion>5.0.0-preview.6.20305.3</MicrosoftDotNetWpfGitHubVersion>
+    <MicrosoftDotNetWpfGitHubVersion>5.0.0-preview.6.20306.1</MicrosoftDotNetWpfGitHubVersion>
     <!-- Not auto-updated. -->
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>

--- a/pkg/windowsdesktop/pkg/Directory.Build.props
+++ b/pkg/windowsdesktop/pkg/Directory.Build.props
@@ -20,6 +20,14 @@
     <GeneratePkg>false</GeneratePkg>
   </PropertyGroup>
 
+  <!-- C++/CLI tooling adds an assemblyref to System.Runtime.InteropServices.WindowsRuntime even though it is unused.
+       Ignore validating this reference when we validate the runtime and ref pack closures since we never use the assembly
+       and it was removed in .NET 5.
+  -->
+  <ItemGroup>
+    <IgnoredReference Include="System.Runtime.InteropServices.WindowsRuntime" />
+  </ItemGroup>
+
   <!-- 
     shared concerns, these shouldn't generally change
     for profile information refere to https://github.com/dotnet/cli/issues/10536#issuecomment-488871926


### PR DESCRIPTION
Ignore the unused System.Runtime.InteropServices.WindowsRuntime reference since that assembly no longer exists.

Currently includes #843 so I could get CI running.

cc: @ryalanms @rladuca @mmitche @jeffschwMSFT 