### PR TITLE
Add new-issue links to other repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--This is just a template - feel free to delete any and all of it and replace as appropriate.-->
+
+### Description
+
+<!--
+* Please share a clear and concise description of the problem.
+* Include minimal steps to reproduce the problem if possible. E.g.: the smallest possible code snippet; or a small repo to clone, with steps to run it.
+* What behavior are you seeing, and what behavior would you expect?
+  -->
+
+### Configuration
+
+<!--
+* Which version of .NET is the code running on?
+* What OS and version, and what distro if applicable?
+* What is the architecture (x64, x86, ARM, ARM64)?
+* Do you know whether it is specific to that configuration?
+  -->
+
+### Regression?
+
+<!--
+* Did this work in a previous build or release of .NET Core, or from .NET Framework? If you can try a previous release or build to find out, that can help us narrow down the problem. If you don't know, that's OK.
+  -->
+
+### Other information
+
+<!--
+* Please include any relevant stack traces or error messages. If possible please include text as text rather than images (so it shows up in searches).
+* If you have an idea where the problem might lie, let us know that here. Please include any pointers to code, relevant changes, or related issues you know of.
+* Do you know of any workarounds?
+  -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue with Windows Forms
+    url:  https://github.com/dotnet/winforms/issues/new/choose
+    about: Please open issues relating to Windows Forms in dotnet/winforms.
+  - name: Issue with WPF
+    url:  https://github.com/dotnet/wpf/issues/new/choose
+    about: Please open issues relating to WPF in dotnet/wpf.
+  - name: Issue with .NET SDK
+    url:  https://github.com/dotnet/sdk/issues/new/choose
+    about: Please open issues relating to the .NET SDK in dotnet/sdk.
+  - name: Issue with .NET runtime or core .NET libraries
+    url:  https://github.com/dotnet/runtime/issues/new/choose
+    about: Please open issues relating to the .NET runtime or core .NET libraries in dotnet/runtime.
+


### PR DESCRIPTION
With this change, "New Issue" takes you to a screen [like this](https://github.com/danmosemsft/windowsdesktop/issues/new/choose)

Note -- I included the bug template from dotnet/runtime, but I'm happy to delete it -- my goal was just to get the config.yml up so that if someone goes to open an issue in this repo, there's links to help them out if it's really a wpf or winforms issue. This matches the pattern used in the runtime, aspnetcore, wpf, winforms etc repos. 

Feel free to close this PR if it's not of value.