### PR TITLE
Apply safern's signing workaround to WindowsDesktop to fix signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,66 +5,70 @@
       Windows arm/arm64 jobs don't have MSIs to sign. Keep it simple: allow not finding any matches
       here and rely on overall signing validation.
     -->
-    <AllowEmptySignList>true</AllowEmptySignList>
+    <AllowEmptySignList Condition="'$(SignFinalPackages)' != 'true'">true</AllowEmptySignList>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!--
-      Replace the default items to sign with the specific set we want. This allows the build to call
-      Arcade's Sign.proj multiple times for different sets of files as the build progresses.
-    -->
-    <ItemsToSign Remove="@(ItemsToSign)" />
+  <Target Name="PrepareItemsToSign" BeforeTargets="Sign">
 
-    <!-- Find bundle artifacts, which need multiple stages to fully sign. -->
-    <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
-    <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
+      <ItemGroup>
+        <!--
+          Replace the default items to sign with the specific set we want. This allows the build to call
+          Arcade's Sign.proj multiple times for different sets of files as the build progresses.
+        -->
+        <ItemsToSign Remove="@(ItemsToSign)" />
 
-    <!-- apphost and comhost template files are not signed, by design. -->
-    <FileSignInfo Include="apphost.exe;comhost.dll" CertificateName="None" />
-  </ItemGroup>
+        <!-- Find bundle artifacts, which need multiple stages to fully sign. -->
+        <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
+        <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
 
-  <ItemGroup Condition="'$(SignBinaries)' == 'true'">
-    <ItemsToSign Include="$(CrossGenRootPath)**/*.dll" />
-  </ItemGroup>
+        <!-- apphost and comhost template files are not signed, by design. -->
+        <FileSignInfo Include="apphost.exe;comhost.dll" CertificateName="None" />
+      </ItemGroup>
 
-  <ItemGroup Condition="'$(SignMsiFiles)' == 'true'">
-    <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.msi" />
-    <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.cab" />
-  </ItemGroup>
+      <ItemGroup Condition="'$(SignBinaries)' == 'true'">
+        <ItemsToSign Include="$(CrossGenRootPath)**/*.dll" />
+      </ItemGroup>
 
-  <ItemGroup Condition="'$(SignBurnEngineFiles)' == 'true'">
-    <ItemsToSign Include="@(BundleInstallerEngineArtifact)" />
-  </ItemGroup>
+      <ItemGroup Condition="'$(SignMsiFiles)' == 'true'">
+        <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.msi" />
+        <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.cab" />
+      </ItemGroup>
 
-  <ItemGroup Condition="'$(SignBurnBundleFiles)' == 'true'">
-    <!-- Sign the bundles, now that the engine is reattached. Avoid re-signing the engine. -->
-    <ItemsToSign
-      Include="@(BundleInstallerExeArtifact)"
-      Exclude="@(BundleInstallerEngineArtifact)" />
-    <!-- Note: wixstdba is internal to the engine bundle and does not get signed. -->
-  </ItemGroup>
+      <ItemGroup Condition="'$(SignBurnEngineFiles)' == 'true'">
+        <ItemsToSign Include="@(BundleInstallerEngineArtifact)" />
+      </ItemGroup>
 
-  <ItemGroup Condition="'$(SignFinalPackages)' == 'true'">
-    <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
-    <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
+      <ItemGroup Condition="'$(SignBurnBundleFiles)' == 'true'">
+        <!-- Sign the bundles, now that the engine is reattached. Avoid re-signing the engine. -->
+        <ItemsToSign
+          Include="@(BundleInstallerExeArtifact)"
+          Exclude="@(BundleInstallerEngineArtifact)" />
+        <!-- Note: wixstdba is internal to the engine bundle and does not get signed. -->
+      </ItemGroup>
 
-    <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
-    <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
-  </ItemGroup>
+      <ItemGroup Condition="'$(SignFinalPackages)' == 'true'">
+        <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
+        <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
 
-  <ItemGroup>
-    <!-- External files -->
-    <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
-  </ItemGroup>
+        <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
+        <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
+      </ItemGroup>
 
-  <ItemGroup>
-    <ItemsToSign Update="@(ItemsToSign)" Authenticode="$(CertificateId)" />
-  </ItemGroup>
+      <ItemGroup>
+        <!-- External files -->
+        <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
+      </ItemGroup>
 
-  <ItemGroup>
-    <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft400" />
-    <FileExtensionSignInfo Include=".pkg" CertificateName="8003" />
-    <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
-  </ItemGroup>
+      <ItemGroup>
+        <ItemsToSign Update="@(ItemsToSign)" Authenticode="$(CertificateId)" />
+      </ItemGroup>
+
+    </Target>
+
+    <ItemGroup>
+        <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft400" />
+        <FileExtensionSignInfo Include=".pkg" CertificateName="8003" />
+        <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
WindowsDesktop binaries are not being signed.  This applies https://github.com/dotnet/runtime/pull/38104/files to WindowsDesktop: ItemGroups are now wrapped in a Target.

Issue #882: [File] filC56A897865C7EB366A736D8CBC788848.dll, Signed: False, Full Name: dotnet\shared\Microsoft.WindowsDesktop.App\5.0.0-preview.7.20323.3\Microsoft.VisualBasic.dll [Error] HRESULT: 800b0100 (No signature ...

