### PR TITLE
Merge publish targets and add signing info to asset manifest

### DIFF
--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -18,6 +18,18 @@ jobs:
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: NuGetAuthenticate@0
+      condition: ne(variables['PostBuildSign'], 'true')
+
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild plugin for Signing
+      inputs:
+        signType: $(SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      continueOnError: false
+      condition: and(succeeded(),
+                     in(variables['SignType'], 'real', 'test'),
+                     ne(variables['PostBuildSign'], 'true'))
 
   - task: DownloadBuildArtifacts@0
     displayName: Download IntermediateUnsignedArtifacts
@@ -25,7 +37,7 @@ jobs:
       artifactName: IntermediateUnsignedArtifacts
       downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
 
-  - script: >-
+  - script: >
       build.cmd -ci
       -projects $(Build.SourcesDirectory)\publish\prepare-artifacts.proj
       /p:Configuration=Release

--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -19,15 +19,6 @@ jobs:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: NuGetAuthenticate@0
 
-  - task: MicroBuildSigningPlugin@2
-    displayName: Install MicroBuild plugin for Signing
-    inputs:
-      signType: $(SignType)
-      zipSources: false
-      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-    continueOnError: false
-    condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
   - task: DownloadBuildArtifacts@0
     displayName: Download IntermediateUnsignedArtifacts
     inputs:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -47,7 +47,29 @@ jobs:
             /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
     steps:
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - task: NuGetAuthenticate@0
+        condition: ne(variables['PostBuildSign'], 'true')
 
+      - task: PowerShell@2
+        displayName: Setup Private Feeds Credentials
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+        env:
+          Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        condition: ne(variables['PostBuildSign'], 'true')
+
+      - task: MicroBuildSigningPlugin@2
+        displayName: Install MicroBuild plugin for Signing
+        inputs:
+          signType: $(SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+        continueOnError: false
+        condition: and(succeeded(), 
+                       in(variables['SignType'], 'real', 'test'),
+                       ne(variables['PostBuildSign'], 'true'))
     # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
     # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
     - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
@@ -59,6 +81,20 @@ jobs:
         $(MsbuildSigningArguments)
         $(_InternalRuntimeDownloadArgs)
       displayName: Build
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: NuGetCommand@2
+        displayName: Push Visual Studio NuPkgs
+        inputs:
+          command: push
+          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
+          nuGetFeedType: external
+          publishFeedCredentials: 'DevDiv - VS package feed'
+        condition: and(
+          succeeded(),
+          eq(variables['_BuildConfig'], 'Release'),
+          ne(variables['DisableVSPublish'], 'true'),
+          ne(variables['PostBuildSign'], 'true'))
 
     - template: steps/upload-job-artifacts.yml
       parameters:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -48,26 +48,6 @@ jobs:
 
     steps:
 
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: NuGetAuthenticate@0
-
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
     # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
     # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
     - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
@@ -79,19 +59,6 @@ jobs:
         $(MsbuildSigningArguments)
         $(_InternalRuntimeDownloadArgs)
       displayName: Build
-
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: NuGetCommand@2
-        displayName: Push Visual Studio NuPkgs
-        inputs:
-          command: push
-          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
-          nuGetFeedType: external
-          publishFeedCredentials: 'DevDiv - VS package feed'
-        condition: and(
-          succeeded(),
-          eq(variables['_BuildConfig'], 'Release'),
-          ne(variables['DisableVSPublish'], 'true'))
 
     - template: steps/upload-job-artifacts.yml
       parameters:

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100-preview.6.20310.4"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20411.8",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20411.8"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20418.5",
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20418.5"
   }
 }

--- a/publish/Directory.Build.targets
+++ b/publish/Directory.Build.targets
@@ -64,6 +64,19 @@
         Condition="Exists('%(Identity)')" />
 
       <UploadToBlobStorageFile Include="@(SymbolNupkgToPublishFile)" />
+
+      <!-- Split nupkgs into shipping/nonshipping for BAR categorization. -->
+      <ShippingNupkgToPublishFile
+        Include="@(NupkgToPublishFile)"
+        Condition="$([System.String]::new('%(Identity)').Contains('\Shipping\'))" />
+
+      <NonShippingNupkgToPublishFile
+        Include="@(NupkgToPublishFile)"
+        Exclude="@(ShippingNupkgToPublishFile)" />
+
+      <ItemsToSign Remove="@(ItemsToSign)" />
+      <ItemsToSign Include="@(DownloadedArtifactFile)"
+                   Exclude="@(DownloadedSymbolNupkgFile)" />
     </ItemGroup>
 
     <Error

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -84,6 +84,9 @@
         <Category>Checksum</Category>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
+
+      <ItemsToSign Remove="@(ItemsToSign)"
+                   Condition="'$(PostBuildSign)' != 'true'" />
     </ItemGroup>
 
     <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="../tools/Sign.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(LocalBuildToolsTaskFile)" />
 
@@ -51,7 +52,8 @@
       Importance="High" />
   </Target>
 
-  <Target Name="PreparePublishToAzureBlobFeed">
+  <Target Name="PreparePublishToAzureBlobFeed"
+          DependsOnTargets="GetProductVersions;FindDownloadedArtifacts">
     <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
 
     <PropertyGroup>
@@ -64,73 +66,35 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- Split nupkgs into shipping/nonshipping for BAR categorization. -->
-      <ShippingNupkgToPublishFile
-        Include="@(NupkgToPublishFile)"
-        Condition="$([System.String]::new('%(Identity)').Contains('\Shipping\'))" />
-
-      <NonShippingNupkgToPublishFile
-        Include="@(NupkgToPublishFile)"
-        Exclude="@(ShippingNupkgToPublishFile)" />
-
       <ItemsToPush Remove="@(ItemsToPush)" />
 
       <ItemsToPush Include="@(ShippingNupkgToPublishFile)" />
       <ItemsToPush Include="@(NonShippingNupkgToPublishFile)" ManifestArtifactData="NonShipping=true" />
       <ItemsToPush Include="@(SymbolNupkgToPublishFile)" />
-    </ItemGroup>
-
-    <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
-    <PushToAzureDevOpsArtifacts
-      ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="Location=$(ExpectedFeedUrl)"
-      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
-      ManifestBranch="$(BUILD_SOURCEBRANCH)"
-      ManifestBuildId="$(BUILD_BUILDNUMBER)"
-      ManifestCommit="$(BUILD_SOURCEVERSION)"
-      IsStableBuild="$(IsStableBuild)"
-      AssetManifestPath="$(AssetManifestFile)"
-      AssetsTemporaryDirectory="$(TempWorkingDir)" />
-
-    <!-- Copy the generated manifest to the build's artifacts -->
-    <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
-
-    <Message Importance="High" Text="Uploading $(AssetManifestFilename) to pipeline" />
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDir)$(AssetManifestFilename)"
-      Importance="High" />
-  </Target>
-
-  <Target Name="PreparePublishFilesToAzureBlobFeed"
-          DependsOnTargets="GetProductVersions">
-    <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
-
-    <PropertyGroup>
-      <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>
-      <AssetManifestFilename>Manifest_Installers.xml</AssetManifestFilename>
-      <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>
-
-      <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
-      <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ItemsToPush Remove="@(ItemsToPush)" />
 
       <ItemsToPush
         Include="@(UploadToBlobStorageFile)"
         Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
 
       <ItemsToPush Include="@(GeneratedChecksumFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
         <Category>Checksum</Category>
+        <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
     </ItemGroup>
 
     <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
     <PushToAzureDevOpsArtifacts
+      AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
+      AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
+      AzureDevOpsBuildId="$(BUILD_BUILDID)"
+      ItemsToSign="@(ItemsToSign)"
+      StrongNameSignInfo="@(StrongNameSignInfo)"
+      FileSignInfo="@(FileSignInfo)"
+      FileExtensionSignInfo="@(FileExtensionSignInfo)"
       ItemsToPush="@(ItemsToPush)"
       ManifestBuildData="Location=$(ExpectedFeedUrl)"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
@@ -138,9 +102,7 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       IsStableBuild="$(IsStableBuild)"
-      PublishFlatContainer="true"
-      AssetManifestPath="$(AssetManifestFile)"
-      AssetsTemporaryDirectory="$(TempWorkingDir)" />
+      AssetManifestPath="$(AssetManifestFile)" />
 
     <!-- Copy the generated manifest to the build's artifacts -->
     <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
@@ -160,8 +122,7 @@
   <Target Name="Build"
           DependsOnTargets="
             UploadPreparedArtifactsToPipeline;
-            PreparePublishToAzureBlobFeed;
-            PreparePublishFilesToAzureBlobFeed">
+            PreparePublishToAzureBlobFeed">
     <Message Importance="High" Text="Complete!" />
   </Target>
 

--- a/signing/Directory.Build.props
+++ b/signing/Directory.Build.props
@@ -5,11 +5,9 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
 
-    <!-- Skip signing steps by default for non-official builds. -->
-    <!-- <SkipSigning Condition="'$(SkipSigning)' == '' and '$(OfficialBuild)' != 'true'">true</SkipSigning> -->
-
-    <!-- Skip signing for validating post-build signing -->
-    <SkipSigning>true</SkipSigning>
+    <!-- Skip signing steps by default for non-official builds or official builds with post-build signing enabled. -->
+    <SkipSigning>$(PostBuildSign)</SkipSigning>
+    <SkipSigning Condition="'$(SkipSigning)' == '' and '$(OfficialBuild)' != 'true'">true</SkipSigning>
   </PropertyGroup>
 
 </Project>

--- a/signing/Directory.Build.props
+++ b/signing/Directory.Build.props
@@ -6,7 +6,10 @@
     <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
 
     <!-- Skip signing steps by default for non-official builds. -->
-    <SkipSigning Condition="'$(SkipSigning)' == '' and '$(OfficialBuild)' != 'true'">true</SkipSigning>
+    <!-- <SkipSigning Condition="'$(SkipSigning)' == '' and '$(OfficialBuild)' != 'true'">true</SkipSigning> -->
+
+    <!-- Skip signing for validating post-build signing -->
+    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
** This is not ready to merge, there are a couple of hard-coded pieces which were just done for testing
    - SkipSigning has been set to true
    - Removed MicroBuild steps from yaml

This partially addresses (WindowsDesktop) - https://github.com/dotnet/core-eng/issues/10459

This change adds signing information into the manifest for this repo, and also merges the manifests so that there is just one.

Test build - https://dnceng.visualstudio.com/internal/_build/results?buildId=785445&view=artifacts&type=publishedArtifacts

@jonfortescue @jcagme @missymessa @mmitche 