### PR TITLE
Create merged manifests

### DIFF
--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -18,15 +18,18 @@ jobs:
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: NuGetAuthenticate@0
+      condition: ne(variables['PostBuildSign'], 'true')
 
-  - task: MicroBuildSigningPlugin@2
-    displayName: Install MicroBuild plugin for Signing
-    inputs:
-      signType: $(SignType)
-      zipSources: false
-      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-    continueOnError: false
-    condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild plugin for Signing
+      inputs:
+        signType: $(SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      continueOnError: false
+      condition: and(succeeded(),
+                     in(variables['SignType'], 'real', 'test'),
+                     ne(variables['PostBuildSign'], 'true'))
 
   - task: DownloadBuildArtifacts@0
     displayName: Download IntermediateUnsignedArtifacts
@@ -34,7 +37,7 @@ jobs:
       artifactName: IntermediateUnsignedArtifacts
       downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
 
-  - script: >-
+  - script: >
       build.cmd -ci
       -projects $(Build.SourcesDirectory)\publish\prepare-artifacts.proj
       /p:Configuration=Release

--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -26,7 +26,6 @@ jobs:
         signType: $(SignType)
         zipSources: false
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      continueOnError: false
       condition: and(succeeded(),
                      in(variables['SignType'], 'real', 'test'),
                      ne(variables['PostBuildSign'], 'true'))

--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -18,7 +18,6 @@ jobs:
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: NuGetAuthenticate@0
-      condition: ne(variables['PostBuildSign'], 'true')
 
     - task: MicroBuildSigningPlugin@2
       displayName: Install MicroBuild plugin for Signing

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -47,9 +47,9 @@ jobs:
             /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
     steps:
-
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: NuGetAuthenticate@0
+        condition: ne(variables['PostBuildSign'], 'true')
 
       - task: PowerShell@2
         displayName: Setup Private Feeds Credentials
@@ -58,6 +58,7 @@ jobs:
           arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
         env:
           Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        condition: ne(variables['PostBuildSign'], 'true')
 
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin for Signing
@@ -66,8 +67,9 @@ jobs:
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
         continueOnError: false
-        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
+        condition: and(succeeded(), 
+                       in(variables['SignType'], 'real', 'test'),
+                       ne(variables['PostBuildSign'], 'true'))
     # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
     # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
     - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
@@ -91,7 +93,8 @@ jobs:
         condition: and(
           succeeded(),
           eq(variables['_BuildConfig'], 'Release'),
-          ne(variables['DisableVSPublish'], 'true'))
+          ne(variables['DisableVSPublish'], 'true'),
+          ne(variables['PostBuildSign'], 'true'))
 
     - template: steps/upload-job-artifacts.yml
       parameters:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -49,7 +49,6 @@ jobs:
     steps:
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: NuGetAuthenticate@0
-        condition: ne(variables['PostBuildSign'], 'true')
 
       - task: PowerShell@2
         displayName: Setup Private Feeds Credentials
@@ -58,7 +57,6 @@ jobs:
           arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
         env:
           Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        condition: ne(variables['PostBuildSign'], 'true')
 
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin for Signing

--- a/publish/Directory.Build.targets
+++ b/publish/Directory.Build.targets
@@ -64,6 +64,19 @@
         Condition="Exists('%(Identity)')" />
 
       <UploadToBlobStorageFile Include="@(SymbolNupkgToPublishFile)" />
+
+      <!-- Split nupkgs into shipping/nonshipping for BAR categorization. -->
+      <ShippingNupkgToPublishFile
+        Include="@(NupkgToPublishFile)"
+        Condition="$([System.String]::new('%(Identity)').Contains('\Shipping\'))" />
+
+      <NonShippingNupkgToPublishFile
+        Include="@(NupkgToPublishFile)"
+        Exclude="@(ShippingNupkgToPublishFile)" />
+
+      <ItemsToSign Remove="@(ItemsToSign)" />
+      <ItemsToSign Include="@(DownloadedArtifactFile)"
+                   Exclude="@(DownloadedSymbolNupkgFile)" />
     </ItemGroup>
 
     <Error

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="../tools/Sign.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(LocalBuildToolsTaskFile)" />
 
@@ -51,7 +52,8 @@
       Importance="High" />
   </Target>
 
-  <Target Name="PreparePublishToAzureBlobFeed">
+  <Target Name="PreparePublishToAzureBlobFeed"
+          DependsOnTargets="GetProductVersions;FindDownloadedArtifacts">
     <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
 
     <PropertyGroup>
@@ -64,73 +66,38 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- Split nupkgs into shipping/nonshipping for BAR categorization. -->
-      <ShippingNupkgToPublishFile
-        Include="@(NupkgToPublishFile)"
-        Condition="$([System.String]::new('%(Identity)').Contains('\Shipping\'))" />
-
-      <NonShippingNupkgToPublishFile
-        Include="@(NupkgToPublishFile)"
-        Exclude="@(ShippingNupkgToPublishFile)" />
-
       <ItemsToPush Remove="@(ItemsToPush)" />
 
       <ItemsToPush Include="@(ShippingNupkgToPublishFile)" />
       <ItemsToPush Include="@(NonShippingNupkgToPublishFile)" ManifestArtifactData="NonShipping=true" />
       <ItemsToPush Include="@(SymbolNupkgToPublishFile)" />
-    </ItemGroup>
-
-    <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
-    <PushToAzureDevOpsArtifacts
-      ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="Location=$(ExpectedFeedUrl)"
-      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
-      ManifestBranch="$(BUILD_SOURCEBRANCH)"
-      ManifestBuildId="$(BUILD_BUILDNUMBER)"
-      ManifestCommit="$(BUILD_SOURCEVERSION)"
-      IsStableBuild="$(IsStableBuild)"
-      AssetManifestPath="$(AssetManifestFile)"
-      AssetsTemporaryDirectory="$(TempWorkingDir)" />
-
-    <!-- Copy the generated manifest to the build's artifacts -->
-    <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
-
-    <Message Importance="High" Text="Uploading $(AssetManifestFilename) to pipeline" />
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDir)$(AssetManifestFilename)"
-      Importance="High" />
-  </Target>
-
-  <Target Name="PreparePublishFilesToAzureBlobFeed"
-          DependsOnTargets="GetProductVersions">
-    <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
-
-    <PropertyGroup>
-      <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>
-      <AssetManifestFilename>Manifest_Installers.xml</AssetManifestFilename>
-      <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>
-
-      <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
-      <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ItemsToPush Remove="@(ItemsToPush)" />
 
       <ItemsToPush
         Include="@(UploadToBlobStorageFile)"
         Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
 
       <ItemsToPush Include="@(GeneratedChecksumFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
         <Category>Checksum</Category>
+        <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
+
+      <ItemsToSign Remove="@(ItemsToSign)"
+                   Condition="'$(PostBuildSign)' != 'true'" />
     </ItemGroup>
 
     <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
     <PushToAzureDevOpsArtifacts
+      AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
+      AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
+      AzureDevOpsBuildId="$(BUILD_BUILDID)"
+      ItemsToSign="@(ItemsToSign)"
+      StrongNameSignInfo="@(StrongNameSignInfo)"
+      FileSignInfo="@(FileSignInfo)"
+      FileExtensionSignInfo="@(FileExtensionSignInfo)"
       ItemsToPush="@(ItemsToPush)"
       ManifestBuildData="Location=$(ExpectedFeedUrl)"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
@@ -138,9 +105,7 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       IsStableBuild="$(IsStableBuild)"
-      PublishFlatContainer="true"
-      AssetManifestPath="$(AssetManifestFile)"
-      AssetsTemporaryDirectory="$(TempWorkingDir)" />
+      AssetManifestPath="$(AssetManifestFile)" />
 
     <!-- Copy the generated manifest to the build's artifacts -->
     <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
@@ -160,8 +125,7 @@
   <Target Name="Build"
           DependsOnTargets="
             UploadPreparedArtifactsToPipeline;
-            PreparePublishToAzureBlobFeed;
-            PreparePublishFilesToAzureBlobFeed">
+            PreparePublishToAzureBlobFeed">
     <Message Importance="High" Text="Complete!" />
   </Target>
 

--- a/signing/Directory.Build.props
+++ b/signing/Directory.Build.props
@@ -5,7 +5,8 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
 
-    <!-- Skip signing steps by default for non-official builds. -->
+    <!-- Skip signing steps by default for non-official builds or official builds with post-build signing enabled. -->
+    <SkipSigning>$(PostBuildSign)</SkipSigning>
     <SkipSigning Condition="'$(SkipSigning)' == '' and '$(OfficialBuild)' != 'true'">true</SkipSigning>
   </PropertyGroup>
 


### PR DESCRIPTION
This partially addresses (WindowsDesktop) - https://github.com/dotnet/core-eng/issues/10459

This change adds signing information into the manifest for this repo, and also merges the manifests so that there is just one.

Test build - https://dnceng.visualstudio.com/internal/_build/results?buildId=785445&view=artifacts&type=publishedArtifacts

@jonfortescue @jcagme @missymessa @mmitche 

Added a "PostBuildSign" variable to the build definition and modified yaml / msbuild files to respect the variable if present.

Validation jobs:
- PostBuildSign == true - https://dnceng.visualstudio.com/internal/_build/results?buildId=787152&view=artifacts&type=publishedArtifacts
  - Creates an asset manifest with ItemsToSign info included

- PostBuildSign == false - https://dnceng.visualstudio.com/internal/_build/results?buildId=787151&view=artifacts&type=publishedArtifacts
  - validates no regressions in build behavior
  - Creates an asset manifest with **no** ItemsToSign info included

Build times with `PostBuildSign == true` are less than half.

PR builds are failing in this branch because... all builds are failing in this branch.  I'll also prepare a PR against release/5.0.

FYI @mmitche @jonfortescue @jcagme @missymessa 