### PR TITLE
Remove explicit add of publishinstallersandchecksums

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -8,7 +8,7 @@ param(
   [Parameter(Mandatory=$false)][string] $EnableSourceLinkValidation,
   [Parameter(Mandatory=$false)][string] $EnableSigningValidation,
   [Parameter(Mandatory=$false)][string] $EnableNugetValidation,
-  [Parameter(Mandatory=$true)][string] $PublishInstallersAndChecksums,
+  [Parameter(Mandatory=$false)][string] $PublishInstallersAndChecksums,
   [Parameter(Mandatory=$false)][string] $ArtifactsPublishingAdditionalParameters,
   [Parameter(Mandatory=$false)][string] $SigningValidationAdditionalParameters
 )
@@ -29,7 +29,7 @@ try {
     $optionalParams.Add("--no-wait") | Out-Null
   }
 
-  if ("true" -eq $PublishInstallersAndChecksums) {
+  if ("false" -ne $PublishInstallersAndChecksums) {
     $optionalParams.Add("--publish-installers-and-checksums") | Out-Null
   }
 
@@ -55,7 +55,6 @@ try {
   --publishing-infra-version $PublishingInfraVersion `
   --default-channels `
   --source-branch master `
-  --publish-installers-and-checksums `
   --azdev-pat $AzdoToken `
   --bar-uri $MaestroApiEndPoint `
   --password $MaestroToken `


### PR DESCRIPTION
https://github.com/dotnet/arcade/commit/6baa6d3c20effeee3631eb33e9e08bcf698a799c breaks the build with an error like

```
Tool 'microsoft.dotnet.darc' (version '1.1.0-beta.20418.1') was successfully installed.
Microsoft.DotNet 1.1.0-beta.20418.1+dfd39d47b1de0cd54ceb2e38005d56cfc71c4b5b
c Microsoft Corporation. All rights reserved.
ERROR(S):
Option 'publish-installers-and-checksums' is defined multiple times.
```

Fixing this by switching the param to be optional, and only omit the parameter if the value is false.

This **should** unblock the build failure which I'm seeing in WindowsDesktop.

https://dev.azure.com/dnceng/internal/_build/results?buildId=797663&view=logs&j=226748d0-f812-5437-d3f0-2dd291f5666e&t=bad11196-972e-5d03-45a8-9db526506073

The eror I see locally, is slightly different than what is in the build though, so that's slightly disconcerting, but this is the failure I see when attempting a local repro

@jcagme, @mmitche 

@jcagme, I'll submit this same change as a PR to arcade repo.
