### PR TITLE
Workaround missing dir

### DIFF
--- a/pkg/Directory.Build.targets
+++ b/pkg/Directory.Build.targets
@@ -26,7 +26,7 @@
     <StableVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' != 'true'">$(Version)</StableVersion>
   </PropertyGroup>
 
-  <!-- Workaround can be removed after repo picks up Arcade sdk 5.0.0-bata.20468.7 or newer -->
+  <!-- Workaround can be removed after repo picks up Arcade sdk 5.0.0-beta.20468.7 or newer -->
   <Target Name="CreateWixOutputFolder"
           BeforeTargets="RunLightLinker">
       <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)"

--- a/pkg/Directory.Build.targets
+++ b/pkg/Directory.Build.targets
@@ -26,6 +26,12 @@
     <StableVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' != 'true'">$(Version)</StableVersion>
   </PropertyGroup>
 
+  <!-- Workaround can be removed after repo picks up Arcade sdk 5.0.0-bata.20468.7 or newer -->
+  <Target Name="CreateWixOutputFolder"
+          BeforeTargets="RunLightLinker">
+      <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)"
+               Condition="!Exists('$(ArtifactsNonShippingPackagesDir)')" />
+  </Target>
   <!--
     Remove duplicate files returned by restore. The resolve task performs extra detection to pick up
     a PDB file for any file listed in the assets file. This causes duplicates if the assets file


### PR DESCRIPTION
Fix for 

```
System.IO.DirectoryNotFoundException: Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\packages\Release\NonShipping\windowsdesktop-targeting-pack-5.0.0-rc.2.20470.2-win-x64.msi.wixpack.zip'.
   at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
   at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)
   at System.IO.Compression.ZipFile.Open(String archiveFileName, ZipArchiveMode mode, Encoding entryNameEncoding)
   at System.IO.Compression.ZipFile.DoCreateFromDirectory(String sourceDirectoryName, String destinationArchiveFileName, Nullable`1 compressionLevel, Boolean includeBaseDirectory, Encoding entryNameEncoding)
   at System.IO.Compression.ZipFile.CreateFromDirectory(String sourceDirectoryName, String destinationArchiveFileName)
   at Microsoft.DotNet.Build.Tasks.Installers.src.CreateWixCommandPackageDropBase.ProcessWixCommand(String packageDropOutputFolder, String toolExecutable, String originalCommand) in /_/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs:line 72
   at Microsoft.DotNet.Build.Tasks.Installers.CreateLightCommandPackageDrop.Execute() in /_/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs:line 34
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
```

will not be necessary after Arcade sdk 5.0.0-beta.20468.7

@mmitche @jcagme , PTAL