### PR TITLE
enable binlog generation when building locally

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore -build %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore -build -bl %*"


### PR DESCRIPTION
Binlogs are produced at the normal location `(<repoRoot>\artifacts\log\<config>\*.binlog)`

These logs are already produced by CIBuild.cmd, but they are not produced by default for local builds using build.cmd. They should be.