### PR TITLE
Remove warnAsError

### DIFF
--- a/eng/stages/publish.yml
+++ b/eng/stages/publish.yml
@@ -14,9 +14,6 @@ stages:
     enableSigningValidation: false
     enableNugetValidation: false
     enableSourceLinkValidation: false
-    # Allow symbol publish to emit expected warnings without failing the build. Include single
-    # quotes inside the string so that it passes through to MSBuild without script interference.
-    symbolPublishingAdditionalParameters: "'-warnAsError:$false'"
     publishInstallersAndChecksums: true
 
     SDLValidationParameters:


### PR DESCRIPTION
This apparently is getting passed through the darc tool down when doing a build promotion. Also this repo doesn't do symbol validation in build or in the build promotion any longer anyway.