### PR TITLE
Enable post build-signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,16 +23,14 @@ variables:
   # Set Official Build Id
   - name: OfficialBuildId
     value: $(Build.BuildNumber)
+  - name: PostBuildSign
+    value: true
 
   # Set the target blob feed for package publish during official and validation builds.
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
-
-  # Fill in missing channel name variables.
-  - name: Net_5_Preview8_Channel_Id
-    value: 1155
 
   # Produce test-signed build for PR and Public builds
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Enables post build signing. This repo will discontinue signing in-build and instead the entire product will sign all at once in the staging pipelines.
Also remove unused, out of date, variable