### PR TITLE
master-to-main default branch rename: enable build triggers for main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,11 +2,13 @@ trigger:
   batch: true
   branches:
     include:
+    - main
     - release/*
     - internal/release/*
     - experimental/*
 
 pr:
+- main
 - release/*
 - experimental/*
 


### PR DESCRIPTION
This is the final step for https://github.com/dotnet/windowsdesktop/issues/1491.

/cc @dotnet/wpf-developers @RussKie 