### PR TITLE
Workaround attempts to publish .symbols.nupkg.sha512 as a symbol package by not generating them

### DIFF
--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -15,6 +15,7 @@
     <ItemGroup>
       <ArtifactsForGeneratingChecksums
         Include="@(UploadToBlobStorageFile)"
+        Exclude="@(SymbolNupkgToPublishFile)"
         DestinationPath="%(FullPath)$(ChecksumExtension)" />
 
       <GeneratedChecksumFile Include="@(ArtifactsForGeneratingChecksums -> '%(DestinationPath)')" />


### PR DESCRIPTION
These aren't useful anyway