### PR TITLE
ARM64 backport to .NET 5:  Cherry-pick Arm64 bundle fix from NET 6

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
     manually enabled by updating the metadata.
   -->
   <ItemGroup>
-    <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />
+    <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="5.0.8" />
   </ItemGroup>
   <!--Package versions-->
   <PropertyGroup>

--- a/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Bundle.bundleproj
+++ b/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Bundle.bundleproj
@@ -6,6 +6,11 @@
       product band to upgrade in place.
     -->
     <BundleInstallerUpgradeCodeSeed>Windows Desktop Shared Framework Bundle Installer</BundleInstallerUpgradeCodeSeed>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <BundleThemeDirectory>$(MSBuildProjectDirectory)</BundleThemeDirectory>
+    <InstallerName>windowsdesktop-runtime</InstallerName>
+    <BundleNameSuffix>Runtime</BundleNameSuffix>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +24,9 @@
   <!-- Obtain the .NET Core Runtime installers from the VS insertion packages. -->
   <Target Name="CollectVSInsertionPackageDownloads"
           BeforeTargets="CollectPackageReferences">
+    <ItemGroup>
+      <_RuntimeIdentifierForNETCoreMsiRestore Include="win-x86;win-x64;win-arm64" />
+    </ItemGroup>
 
     <ItemGroup>
       <InsertionPackageRID


### PR DESCRIPTION
**Description**

Backport NET6 WPF ARM64 and enable WinForms ARM64 support on NET5.  

* Add NET5 WPF ARM64 support.

* Unblock WinForms on NET5 ARM64, working but disabled on NET5 due to lack of WPF ARM64 support.

**Public PRs**

WPF public (these PRs need to go in separately due to WPF internal relying on the WPF Arcade SDK package): 
https://github.com/dotnet/wpf/pull/4522
https://github.com/dotnet/wpf/pull/4523

WindowsDesktop:
https://github.com/dotnet/windowsdesktop/pull/1629

SDK:
No changes are required in main. 

Installer: 
WindowsDesktop NET5 ARM64: Include WindowsDesktop ARM64 in the Installer by ryalanms · Pull Request #10699 · dotnet/installer (github.com)


**Customer Impact**

These changes allow existing NET5 customers to build WPF and WinForms applications for ARM64


**Regression?**

No.  This is a new feature.  

WinForms was available in NET5 preview, then disabled, due to lack of WPF ARM64 support.  This unblocks WinForms.  


**Risk**

Low.   

There are no existing ARM64 WPF or WinForms application on NET5 to break, and these changes have been in NET 6 Preview since Preview 1.  

Some files that have conditionally compiled sections shared with x86/x64.  There is a small risk of a regression due these modifications.

The addition of new packages and changes to the Installer pose some risk, but we have built and tested all PRs end-to-end (locally and through Azure) and tested the Installer on arm64 and x64/x86.  


**Is there a packaging impact?**

Yes.  This requires new runtime and targeting packs.  


**Testing**

Manual and automated testing was performed on a local test Installer build, created with the E2E changes from all five repos.  An E2E build on Azure using the PRs (with required feed and version updates) was also created to verify that we will not introduce build issues. 

WPF has ported 49% of the netcore test automation to ARM64.  There are parts of the test infrastructure (touch driver, printer driver, and others) that do not have ARM64 versions available and must be rewritten.  Manual tests were run to fill in the test gaps.  

For the manual tests, 202 test applications from WPF’s samples repo were built and run.  The sample application behavior was compared against the same applications running on NET5 x64 and net6 ARM64.  There were no differences observed between NET6 ARM64 and NET5 ARM64.

All ported test automation was run against the current NET5 x86 and NET5 x64 builds (without any changes), and results were compared against NET5 ARM64.  There are five failures that are being investigated, but we do not consider these blocking. 

For regression testing, a full test pass was run against x86 and x64 NET5 Installer builds containing the WPF ARM64 changes.  This covered all OS versions: Windows 7 SP1, Windows Blue, Windows Server 2012 R2 SP1, Win10 RS1, RS3, RS4, Server 2019, 21H1, Server 2016, 19H1, 19H2, 20H1, 20H2.  No new issues were found (introduced due to these changes) with x86 or x64.

Non-functioning bitmap effects were discovered, Blur and DropShadow, which work on non-ARM64 plaforms, but are considered non-blocking.  No blocking issues were found in automation or manual testing.

Co-authored-by: Alexandre Zollinger Chohfi <...>
Co-authored-by: Marcpems <...>
Co-authored-by: Juan Sebastian Hoyos Ayala <...> 
Co-authored-by: Ryland <41491307+ryalanms@users.noreply.github.com>

/cc @azchohfi @hoyosjs @marcpems