### PR TITLE
Coherency fixes of runtime dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,10 +5,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>691c12bc9e4f8b7615e8108d57699485d5a67ea7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="6.0.0-preview.5.21254.12" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>65020c946254c9a99497f4fdfa4136131f51f913</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21270.12" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>691c12bc9e4f8b7615e8108d57699485d5a67ea7</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,7 +52,6 @@
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-preview.5.21270.12</MicrosoftNETCoreAppRuntimewinx64Version>
     <!-- corefx -->
     <MicrosoftNETCorePlatformsVersion>6.0.0-preview.5.21270.12</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNETCoreTargetsVersion>6.0.0-preview.5.21254.12</MicrosoftNETCoreTargetsVersion>
     <MicrosoftWin32RegistryAccessControlVersion>6.0.0-preview.5.21270.12</MicrosoftWin32RegistryAccessControlVersion>
     <MicrosoftWin32RegistryVersion>6.0.0-preview.5.21270.12</MicrosoftWin32RegistryVersion>
     <MicrosoftWin32SystemEventsVersion>6.0.0-preview.5.21270.12</MicrosoftWin32SystemEventsVersion>
@@ -67,7 +66,6 @@
     <SystemIOPipesAccessControlVersion>6.0.0-preview.5.21270.12</SystemIOPipesAccessControlVersion>
     <SystemResourcesExtensionsVersion>6.0.0-preview.5.21270.12</SystemResourcesExtensionsVersion>
     <SystemSecurityAccessControlVersion>6.0.0-preview.5.21270.12</SystemSecurityAccessControlVersion>
-    <SystemSecurityCryptographyCngVersion>6.0.0-preview.5.21224.4</SystemSecurityCryptographyCngVersion>
     <SystemSecurityCryptographyPkcsVersion>6.0.0-preview.5.21270.12</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyProtectedDataVersion>6.0.0-preview.5.21270.12</SystemSecurityCryptographyProtectedDataVersion>
     <SystemSecurityCryptographyXmlVersion>6.0.0-preview.5.21270.12</SystemSecurityCryptographyXmlVersion>


### PR DESCRIPTION
`Microsoft.NETCore.Targets` and `System.Security.Cryptography.Cng` got removed (see https://github.com/dotnet/runtime/pull/52261, https://github.com/dotnet/runtime/pull/51853) and cause incoherent builds.