### PR TITLE
Package Windows Forms analyzers

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -73,17 +73,17 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d019e70d2b7c2f7cd1137fac084dbcdc3d2e05f5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Private.Winforms" Version="6.0.0-rc.1.21375.2" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
+    <Dependency Name="Microsoft.Private.Winforms" Version="6.0.0-rc.1.21375.3" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>62cd8407157a73270e30c8cf9d4fbd5182d9e749</Sha>
+      <Sha>9db7e3b7458107186f31a02627e29cb4a0ccefcf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="6.0.0-rc.1.21375.2">
+    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="6.0.0-rc.1.21376.1">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>e10567abedbc9db22d2d6860e64409a41e0a08af</Sha>
+      <Sha>148aa5c980273e47c9628b26e47de1c35831ce80</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="6.0.0-rc.1.21375.2">
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="6.0.0-rc.1.21376.1">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>e10567abedbc9db22d2d6860e64409a41e0a08af</Sha>
+      <Sha>148aa5c980273e47c9628b26e47de1c35831ce80</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-rc.1.21374.7" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -101,13 +101,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d019e70d2b7c2f7cd1137fac084dbcdc3d2e05f5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="6.0.0-rc.1.21375.2" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="6.0.0-rc.1.21375.3" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>62cd8407157a73270e30c8cf9d4fbd5182d9e749</Sha>
+      <Sha>9db7e3b7458107186f31a02627e29cb4a0ccefcf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="6.0.0-rc.1.21375.2">
+    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="6.0.0-rc.1.21376.1">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>e10567abedbc9db22d2d6860e64409a41e0a08af</Sha>
+      <Sha>148aa5c980273e47c9628b26e47de1c35831ce80</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,8 +18,8 @@
     <NETCoreAppMaximumVersion>6.0</NETCoreAppMaximumVersion>
     <NETCoreAppFrameworkVersion>6.0</NETCoreAppFrameworkVersion>
     <NETCoreAppFramework>net$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
-    <MicrosoftDotnetWinFormsProjectTemplatesVersion>6.0.0-rc.1.21375.2</MicrosoftDotnetWinFormsProjectTemplatesVersion>
-    <MicrosoftDotNetWpfProjectTemplatesVersion>6.0.0-rc.1.21375.2</MicrosoftDotNetWpfProjectTemplatesVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesVersion>6.0.0-rc.1.21375.3</MicrosoftDotnetWinFormsProjectTemplatesVersion>
+    <MicrosoftDotNetWpfProjectTemplatesVersion>6.0.0-rc.1.21376.1</MicrosoftDotNetWpfProjectTemplatesVersion>
   </PropertyGroup>
   <!--
     Servicing build settings for setup packages. Instructions:
@@ -71,9 +71,9 @@
     <SystemThreadingAccessControlVersion>6.0.0-rc.1.21374.7</SystemThreadingAccessControlVersion>
     <SystemWindowsExtensionsVersion>6.0.0-rc.1.21374.7</SystemWindowsExtensionsVersion>
     <!-- winforms -->
-    <MicrosoftPrivateWinformsVersion>6.0.0-rc.1.21375.2</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>6.0.0-rc.1.21375.3</MicrosoftPrivateWinformsVersion>
     <!-- wpf -->
-    <MicrosoftDotNetWpfGitHubVersion>6.0.0-rc.1.21375.2</MicrosoftDotNetWpfGitHubVersion>
+    <MicrosoftDotNetWpfGitHubVersion>6.0.0-rc.1.21376.1</MicrosoftDotNetWpfGitHubVersion>
     <!-- Not auto-updated. -->
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>

--- a/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
+++ b/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
@@ -2,7 +2,6 @@
   <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" />
   <PropertyGroup>
     <PlatformPackageType>TargetingPack</PlatformPackageType>
-    <WindowsFormsClassificationProps>$(PkgMicrosoft_Private_Winforms)\FrameworkListFiles.props</WindowsFormsClassificationProps>
     <RuntimePackProjectPath>$(MSBuildThisFileDirectory)Microsoft.WindowsDesktop.App.Runtime.sfxproj</RuntimePackProjectPath>
     <ArchiveName>windowsdesktop-targeting-pack</ArchiveName>
     <InstallerName>windowsdesktop-targeting-pack</InstallerName>
@@ -11,8 +10,8 @@
   </PropertyGroup>
 
   <!-- 
-    shared concerns, these shouldn't generally change
-    for profile information refere to https://github.com/dotnet/cli/issues/10536#issuecomment-488871926
+    Shared concerns, these shouldn't generally change
+    For profile information refer to https://github.com/dotnet/cli/issues/10536#issuecomment-488871926
     -->
   <ItemGroup>
     <FrameworkListFileClass Include="Accessibility.dll" Profile="WindowsForms;WPF" />
@@ -36,9 +35,10 @@
 
   <!-- 
     Windows Forms specific references
-    see: https://github.com/dotnet/winforms/pull/2707/commits/50a5258f7039dc81d99b1c3896a94c578387a3be
+    see: https://github.com/dotnet/winforms/tree/main/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop
     -->
-  <Import Project="$(WindowsFormsClassificationProps)" Condition="Exists('$(WindowsFormsClassificationProps)')" />
+  <Import Project="$(PkgMicrosoft_Private_Winforms)\sdk\dotnet-windowsdesktop\System.Windows.Forms.FileClassification.props"
+          Condition="Exists('$(PkgMicrosoft_Private_Winforms)')" />
 
   <!-- WPF specific references -->
   <ItemGroup>
@@ -68,4 +68,8 @@
     <!-- We don't have a ref assembly for DirectWriteForwarder -->
     <IgnoredReference Include="DirectWriteForwarder" />
   </ItemGroup>
+
+  <!-- Windows Forms validation and packaging -->
+  <Import Project="WindowsForms.Packaging.targets" />
+
 </Project>

--- a/pkg/windowsdesktop/sfx/WindowsForms.Packaging.targets
+++ b/pkg/windowsdesktop/sfx/WindowsForms.Packaging.targets
@@ -1,0 +1,68 @@
+<!--
+    This props file comes from dotnet/winforms. It gets ingested by dotnet/windowsdesktop and processed by
+    pkg\windowsdesktop\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj.
+   -->
+
+<Project>
+
+  <PropertyGroup>
+    <_WindowsFormsNuGetPath>$(PkgMicrosoft_Private_Winforms)</_WindowsFormsNuGetPath>
+  </PropertyGroup>
+
+  <!--
+    ============================================================
+                      _ValidateWindowsFormsPackagingContent
+    Validates the content of Microsoft.Private.Winforms NuGet package
+    to ensure we correctly import and reference props and targets.
+    ============================================================
+   -->
+  <Target Name="_ValidateWindowsFormsPackagingContent"
+          BeforeTargets="PrepareForBuild">
+
+    <PropertyGroup>
+      <_WindowsFormsRequiredFileName>System.Windows.Forms.FileClassification.props</_WindowsFormsRequiredFileName>
+    </PropertyGroup>
+
+    <Error Text="Unable to resolve path to Microsoft.Private.Winforms NuGet package. Is %24(PkgMicrosoft_Private_Winforms) defined?"
+           Condition="'$(_WindowsFormsNuGetPath)' == ''"/>
+
+    <ItemGroup>
+      <!-- Enumerate all transported files -->
+      <_WindowsFormsContent Include="$(_WindowsFormsNuGetPath)/sdk/analyzers/**/*.*" />
+      <_WindowsFormsContent Include="$(_WindowsFormsNuGetPath)/sdk/dotnet-windowsdesktop/*" />
+
+      <!-- ...and verify System.Windows.Forms.FileClassification.props is present -->
+      <_WindowsFormsContentFiles Include="@(_WindowsFormsContent->'%(FileName)%(Extension)')"
+          Condition=" '%(FileName)%(Extension)' == '$(_WindowsFormsRequiredFileName)' "/>
+      <!-- ...and analyzers are present too -->
+      <_WindowsFormsContentFiles Include="@(_WindowsFormsContent->'%(FileName)%(Extension)')"
+          Condition="$([System.String]::Copy('%(Filename)').Contains('Analyzer', StringComparison.OrdinalIgnoreCase)) "/>
+          <!--  -->
+    </ItemGroup>
+
+    <!-- Fail if the required files are missing -->
+    <Error Text="Microsoft.Private.Winforms NuGet package does not contain $(_WindowsFormsRequiredFileName) or analyzers"
+           Condition="@(_WindowsFormsContentFiles->Count()) &lt; 2"/>
+  </Target>
+
+
+  <!--
+    ============================================================
+                      _IdentifyWindowsFormsPackageAssets
+    Add props/targets shipped by Windows Forms to the collection of files that get packaged
+    in to Microsoft.NET.Sdk.WindowsDesktop.<configuration>.<version>.nupkg.
+    ============================================================
+  -->
+  <Target Name="_IdentifyWindowsFormsPackageAssets"
+          BeforeTargets="_GenerateFrameworkList"
+          DependsOnTargets="_ValidateWindowsFormsPackagingContent">
+
+    <!-- Package our analyzer into the Windows Desktop shipping bundles -->
+    <ItemGroup>
+      <WindowsFormsAnalyzers Include="$(PkgMicrosoft_Private_Winforms)/sdk/analyzers/**/*.*" />
+      <FilesToPackage Include="@(WindowsFormsAnalyzers)" ExcludeFromValidation="true" TargetPath="analyzers/%(RecursiveDir)" />
+    </ItemGroup>
+  </Target>
+
+
+</Project>


### PR DESCRIPTION
Unblocks: https://github.com/dotnet/winforms/pull/5035

Inbox Windows Forms analyzers into Windows Desktop SDK as per https://github.com/dotnet/designs/blob/main/accepted/2021/InboxSourceGenerators.md

* The analyzers and source generators come from a Windows Forms transport package built and packaged by https://github.com/dotnet/winforms/tree/main/pkg/Microsoft.Private.Winforms project. The analyzers are placed under .\sdk\analyzers folder, so that when the transport package is ingested the analyzers would not get imported by the ingesting projects (e.g. this project or dotnet/wpf).
* Add validation to verify the Windows Forms transport package contains the required content.
* And while at it, update the way the Windows Forms file classifications are referenced.


* Windows Forms transport package (published to [general-testing-internal feed](https://dev.azure.com/dnceng/internal/_packaging?_a=package&feed=general-testing-internal&package=Microsoft.Private.Winforms&protocolType=NuGet&version=6.0.0-rc.1.21378.1))
![image](https://user-images.githubusercontent.com/4403806/127324099-47bd19a8-5c2e-4509-bcd3-cdc59c379773.png)

* Windows Desktop package
![image](https://user-images.githubusercontent.com/4403806/127323932-2df7723f-fa45-41c7-ae30-d127a32b6070.png)

* End result:
![image](https://user-images.githubusercontent.com/4403806/127326957-dda4eb58-04b8-4d3e-9d9a-9394a8aaca40.png)
