### PR TITLE
Fix SharedFramework auto-update and update it to match current Arcade version.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -143,9 +143,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>85a65ea1fca1d0867f699fed44d191358270bf6a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework" Version="6.0.0-beta.21057.6">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.21304.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4f2a6ff4dac709dcc71832f828a7d40da0343e16</Sha>
+      <Sha>85a65ea1fca1d0867f699fed44d191358270bf6a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="6.0.0-beta.21304.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21304.1",
-    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21057.6",
+    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21304.1",
     "Microsoft.Build.NoTargets": "1.0.53"
   }
 }


### PR DESCRIPTION
The entry in Version.Details.xml for the SharedFramework SDK was invalid.

Fix it and update the package to match the rest of the Arcade tooling so auto-updates will kick in.

cc: @mmitche