### PR TITLE
Build against version Preview 6 of the .NET SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.4.21255.9"
+    "dotnet": "6.0.100-preview.6.21317.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21363.2",


### PR DESCRIPTION
Build against version Preview 6 of the .NET SDK.  WindowsDesktop is currently building against Preview 4.  WinForms and WPF are building against Preview 6.