### PR TITLE
WindowsDesktop relies on some refpack changes not in p6.  Build against p7 instead.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.6.21317.3"
+    "dotnet": "6.0.100-preview.7.21364.30"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21363.2",


### PR DESCRIPTION
WindowsDesktop relies on some refpack changes not in p6.  Build against p7 instead.

Update global.json to 6.0.100-preview.7.21364.30.  