### PR TITLE
Windows Desktop Runtime installer for arm64 should also include the .NET runtime

### DIFF
--- a/pkg/windowsdesktopRIDs.props
+++ b/pkg/windowsdesktopRIDs.props
@@ -14,7 +14,7 @@
   <ItemGroup>
     <OfficialBuildRID Include="win-x86" Platform="x86" RuntimeMsiExists="true"/>
     <OfficialBuildRID Include="win-x64" RuntimeMsiExists="true"/>
-    <OfficialBuildRID Include="win-arm64" Platform="arm64" />
+    <OfficialBuildRID Include="win-arm64" Platform="arm64" RuntimeMsiExists="true"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
ARM64 applications that are not published as self-contained require both the Runtime and Windows Desktop Runtime (or the SDK) to be installed on the ARM64 machine in order to run the app.  

The current Windows Desktop Runtime installer only contains: 

*Microsoft Windows Desktop Runtime*

The installer should also include the .NET Runtime: 

*Microsoft .NET Host*
*Microsoft .NET Host FX Resolver*
*Microsoft .NET Runtime*
