### PR TITLE
Consume transport pack from dotnet/runtime

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.WindowsDesktop.Internal.Transport" Version="6.0.0-rc.1.21413.7">
+    <Dependency Name="Microsoft.Internal.Runtime.WindowsDesktop.Transport" Version="6.0.0-rc.1.21416.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>65e50657278f6a3af5ccb7ac6def8d5baa5dd490</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,77 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.WindowsDesktop.Internal.Transport" Version="6.0.0-rc.1.21413.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.CodeDom" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Text.Json" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
+      <Sha>65e50657278f6a3af5ccb7ac6def8d5baa5dd490</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Private.Winforms" Version="6.0.0-rc.1.21412.6" CoherentParentDependency="Microsoft.DotNet.Wpf.GitHub">
       <Uri>https://github.com/dotnet/winforms</Uri>
@@ -94,10 +26,6 @@
       <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="6.0.0-rc.1.21411.5" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0ea8653e1f0ada5c7a15515430c6f16585911af4</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,7 +49,7 @@
     <!-- runtime -->
     <MicrosoftNETCoreAppRefVersion>6.0.0-rc.1.21411.5</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-rc.1.21411.5</MicrosoftNETCoreAppRuntimewinx64Version>
-    <MicrosoftWindowsDesktopInternalTransportVersion>6.0.0-rc.1.21413.7</MicrosoftWindowsDesktopInternalTransportVersion>
+    <MicrosoftInternalRuntimeWindowsDesktopTransportVersion>6.0.0-rc.1.21416.10</MicrosoftInternalRuntimeWindowsDesktopTransportVersion>
     <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21411.5</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
     <!-- winforms -->
     <MicrosoftPrivateWinformsVersion>6.0.0-rc.1.21412.6</MicrosoftPrivateWinformsVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,30 +46,11 @@
     <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21410.8</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.21410.8</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.21410.8</MicrosoftDotNetVersionToolsTasksVersion>
-    <!-- core-setup -->
+    <!-- runtime -->
     <MicrosoftNETCoreAppRefVersion>6.0.0-rc.1.21411.5</MicrosoftNETCoreAppRefVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21411.5</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-rc.1.21411.5</MicrosoftNETCoreAppRuntimewinx64Version>
-    <!-- corefx -->
-    <MicrosoftNETCorePlatformsVersion>6.0.0-rc.1.21411.5</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftWin32RegistryAccessControlVersion>6.0.0-rc.1.21411.5</MicrosoftWin32RegistryAccessControlVersion>
-    <MicrosoftWin32SystemEventsVersion>6.0.0-rc.1.21411.5</MicrosoftWin32SystemEventsVersion>
-    <SystemCodeDomVersion>6.0.0-rc.1.21411.5</SystemCodeDomVersion>
-    <SystemConfigurationConfigurationManagerVersion>6.0.0-rc.1.21411.5</SystemConfigurationConfigurationManagerVersion>
-    <SystemDiagnosticsEventLogVersion>6.0.0-rc.1.21411.5</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounterVersion>6.0.0-rc.1.21411.5</SystemDiagnosticsPerformanceCounterVersion>
-    <SystemDirectoryServicesVersion>6.0.0-rc.1.21411.5</SystemDirectoryServicesVersion>
-    <SystemDrawingCommonVersion>6.0.0-rc.1.21411.5</SystemDrawingCommonVersion>
-    <SystemIOPackagingVersion>6.0.0-rc.1.21411.5</SystemIOPackagingVersion>
-    <SystemResourcesExtensionsVersion>6.0.0-rc.1.21411.5</SystemResourcesExtensionsVersion>
-    <SystemSecurityCryptographyPkcsVersion>6.0.0-rc.1.21411.5</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyProtectedDataVersion>6.0.0-rc.1.21411.5</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlVersion>6.0.0-rc.1.21411.5</SystemSecurityCryptographyXmlVersion>
-    <SystemSecurityPermissionsVersion>6.0.0-rc.1.21411.5</SystemSecurityPermissionsVersion>
-    <SystemTextEncodingsWebVersion>6.0.0-rc.1.21411.5</SystemTextEncodingsWebVersion>
-    <SystemTextJsonVersion>6.0.0-rc.1.21411.5</SystemTextJsonVersion>
-    <SystemThreadingAccessControlVersion>6.0.0-rc.1.21411.5</SystemThreadingAccessControlVersion>
-    <SystemWindowsExtensionsVersion>6.0.0-rc.1.21411.5</SystemWindowsExtensionsVersion>
+    <MicrosoftWindowsDesktopInternalTransportVersion>6.0.0-rc.1.21413.7</MicrosoftWindowsDesktopInternalTransportVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21411.5</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
     <!-- winforms -->
     <MicrosoftPrivateWinformsVersion>6.0.0-rc.1.21412.6</MicrosoftPrivateWinformsVersion>
     <!-- wpf -->
@@ -83,14 +64,6 @@
     <NugetProjectModelVersion>4.9.4</NugetProjectModelVersion>
     <NugetPackagingVersion>4.9.4</NugetPackagingVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.7.0</MicrosoftDiaSymReaderNativeVersion>
-  </PropertyGroup>
-  <!--Package names-->
-  <PropertyGroup>
-    <MicrosoftDotNetBuildTasksFeedPackage>Microsoft.DotNet.Build.Tasks.Feed</MicrosoftDotNetBuildTasksFeedPackage>
-    <MicrosoftNETCorePlatformsPackage>Microsoft.NETCore.Platforms</MicrosoftNETCorePlatformsPackage>
-    <MicrosoftNETCoreTargetsPackage>Microsoft.NETCore.Targets</MicrosoftNETCoreTargetsPackage>
-    <MicrosoftBclJsonSourcesPackage>Microsoft.Bcl.Json.Sources</MicrosoftBclJsonSourcesPackage>
-    <MicrosoftSymbolUploaderBuildTaskPackage>Microsoft.SymbolUploader.Build.Task</MicrosoftSymbolUploaderBuildTaskPackage>
   </PropertyGroup>
   <!-- Base runtime pack name (RID-less) for shared framework tooling. -->
   <PropertyGroup>

--- a/pkg/windowsdesktop/sfx/Directory.Build.props
+++ b/pkg/windowsdesktop/sfx/Directory.Build.props
@@ -19,21 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Wpf.GitHub" Version="$(MicrosoftDotNetWpfGitHubVersion)" />
     <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="$(MicrosoftWin32RegistryAccessControlVersion)" />
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsVersion)" />
-    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounterVersion)" />
-    <PackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
-    <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
-    <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
-    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
-    <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
-    <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsVersion)" />
+    <PackageReference Include="Microsoft.WindowsDesktop.Internal.Transport" Version="$(MicrosoftWindowsDesktopInternalTransportVersion)" />
   </ItemGroup>
 </Project>

--- a/pkg/windowsdesktop/sfx/Directory.Build.props
+++ b/pkg/windowsdesktop/sfx/Directory.Build.props
@@ -19,6 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Wpf.GitHub" Version="$(MicrosoftDotNetWpfGitHubVersion)" />
     <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.WindowsDesktop.Internal.Transport" Version="$(MicrosoftWindowsDesktopInternalTransportVersion)" />
+    <PackageReference Include="Microsoft.Internal.Runtime.WindowsDesktop.Transport" Version="$(MicrosoftInternalRuntimeWindowsDesktopTransportVersion)" />
   </ItemGroup>
 </Project>

--- a/publish/Directory.Build.props
+++ b/publish/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="$(MicrosoftDotNetBuildTasksFeedPackage)" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
     <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
dotnet/runtime packages don't contain reference assemblies anymore. As
windowsdesktop distributes some of dotnet/runtime's reference assemblies
in their targeting pack, consuming a transport package from
dotnet/runtime which contains all the required assets (ref + lib + docs)

Removing stale properties and subscriptions as well.

cc @ericstj @Anipik 