### PR TITLE
Remove unused Build.Tasks.Packaging version

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,11 +1,5 @@
 <Project>
 
-  <!-- source-built packages -->
-  <ItemGroup>
-    <!-- arcade -->
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" />
-  </ItemGroup>
-
   <!-- excluded from source build -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -55,10 +55,6 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>fe787bd48ed72e51a98eb5e4e5e5af74edb531e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="6.0.0-beta.21420.4">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fe787bd48ed72e51a98eb5e4e5e5af74edb531e5</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.21420.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>fe787bd48ed72e51a98eb5e4e5e5af74edb531e5</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,6 @@
     <!-- arcade -->
     <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21420.4</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.21420.4</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21420.4</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.21420.4</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.21420.4</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- runtime -->


### PR DESCRIPTION
The Microsoft.DotNet.Build.Tasks.Packaging package isn't used in this repo, hence removing the version. We are planning to deprecate that project in the future, so that's in preparation for that.