### PR TITLE
Generate a version metadata file which can be used by dotnet-install

### DIFF
--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -61,7 +61,17 @@
 
       <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
       <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
+
+      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'=='true'">$(ProductionVersion)</ProductVersionTxtContents>
+      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'!='true'">$(ProductVersion)</ProductVersionTxtContents>
     </PropertyGroup>
+
+    <!-- Generate productVersion.txt containing the value of $(PackageVersion) -->
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)productVersion.txt"
+      Lines="$(ProductVersionTxtContents)"
+      Overwrite="true"
+      Encoding="ASCII" />
 
     <ItemGroup>
       <ItemsToPush Remove="@(ItemsToPush)" />
@@ -82,6 +92,11 @@
         <Category>Checksum</Category>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
+
+      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
+        <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
+      </ItemsToPush>
+
     </ItemGroup>
 
     <!--

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -139,13 +139,7 @@
 
     <Target Name="PreparePublishFilesToAzureBlobFeed"
           DependsOnTargets="GetProductVersions">
-    <!--
-    <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
-    -->
     <PropertyGroup>
-      <!--
-      <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>
-      -->
 
       <AssetManifestFilename>Manifest.xml</AssetManifestFilename>
       <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>
@@ -158,9 +152,9 @@
 
     </PropertyGroup>
 
-    <!-- Generate productVersion.txt containing the value of $(PackageVersion) -->
+    <!-- Generate windowsdesktop-productVersion.txt containing the value of $(PackageVersion) -->
     <WriteLinesToFile
-      File="$(ArtifactsShippingPackagesDir)productVersion.txt"
+      File="$(ArtifactsShippingPackagesDir)windowsdesktop-productVersion.txt"
       Lines="$(ProductVersionTxtContents)"
       Overwrite="true"
       Encoding="ASCII" />
@@ -168,20 +162,8 @@
     <ItemGroup>
       <ItemsToPush Remove="@(ItemsToPush)" />
 
-      <!--
-      <ItemsToPush
-        Include="@(UploadToBlobStorageFile)"
-        Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)">
-        <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
-      </ItemsToPush>
-      <ItemsToPush Include="@(GeneratedChecksumFile)">
-        <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
-        <Category>Checksum</Category>
-      </ItemsToPush>
-      -->
-
-      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
-        <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
+      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)windowsdesktop-productVersion.txt">
+        <RelativeBlobPath>$(InstallersRelativePath)windowsdesktop-productVersion.txt</RelativeBlobPath>
       </ItemsToPush>
 
     </ItemGroup>

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -139,7 +139,9 @@
 
     <Target Name="PreparePublishFilesToAzureBlobFeed"
           DependsOnTargets="GetProductVersions">
+    <!--
     <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
+    -->
     <PropertyGroup>
       <!--
       <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -61,17 +61,7 @@
 
       <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
       <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
-
-      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'=='true'">$(ProductionVersion)</ProductVersionTxtContents>
-      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'!='true'">$(ProductVersion)</ProductVersionTxtContents>
     </PropertyGroup>
-
-    <!-- Generate productVersion.txt containing the value of $(PackageVersion) -->
-    <WriteLinesToFile
-      File="$(ArtifactsShippingPackagesDir)productVersion.txt"
-      Lines="$(ProductVersionTxtContents)"
-      Overwrite="true"
-      Encoding="ASCII" />
 
     <ItemGroup>
       <ItemsToPush Remove="@(ItemsToPush)" />
@@ -92,11 +82,6 @@
         <Category>Checksum</Category>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
-
-      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
-        <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
-      </ItemsToPush>
-
     </ItemGroup>
 
     <!--
@@ -152,6 +137,73 @@
       Importance="High" />
   </Target>
 
+    <Target Name="PreparePublishFilesToAzureBlobFeed"
+          DependsOnTargets="GetProductVersions">
+    <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
+    <PropertyGroup>
+      <!--
+      <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>
+      -->
+
+      <AssetManifestFilename>Manifest.xml</AssetManifestFilename>
+      <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>
+
+      <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
+      <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
+
+      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'=='true'">$(ProductionVersion)</ProductVersionTxtContents>
+      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'!='true'">$(ProductVersion)</ProductVersionTxtContents>
+
+    </PropertyGroup>
+
+    <!-- Generate productVersion.txt containing the value of $(PackageVersion) -->
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)productVersion.txt"
+      Lines="$(ProductVersionTxtContents)"
+      Overwrite="true"
+      Encoding="ASCII" />
+
+    <ItemGroup>
+      <ItemsToPush Remove="@(ItemsToPush)" />
+
+      <!--
+      <ItemsToPush
+        Include="@(UploadToBlobStorageFile)"
+        Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)">
+        <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
+      </ItemsToPush>
+      <ItemsToPush Include="@(GeneratedChecksumFile)">
+        <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
+        <Category>Checksum</Category>
+      </ItemsToPush>
+      -->
+
+      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
+        <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
+      </ItemsToPush>
+
+    </ItemGroup>
+
+    <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
+    <PushToAzureDevOpsArtifacts
+      ItemsToPush="@(ItemsToPush)"
+      ManifestBuildData="@(ManifestBuildData)"
+      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
+      ManifestBranch="$(BUILD_SOURCEBRANCH)"
+      ManifestBuildId="$(BUILD_BUILDNUMBER)"
+      ManifestCommit="$(BUILD_SOURCEVERSION)"
+      IsStableBuild="$(IsStableBuild)"
+      PublishFlatContainer="true"
+      AssetManifestPath="$(AssetManifestFile)"
+      AssetsTemporaryDirectory="$(TempWorkingDir)" />
+    <!-- Copy the generated manifest to the build's artifacts -->
+    <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
+    <Message Importance="High" Text="Uploading $(AssetManifestFilename) to pipeline" />
+    <Message
+      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDir)$(AssetManifestFilename)"
+      Importance="High" />
+  </Target>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <!--
@@ -161,7 +213,8 @@
   <Target Name="Build"
           DependsOnTargets="
             UploadPreparedArtifactsToPipeline;
-            PreparePublishToAzureBlobFeed">
+            PreparePublishToAzureBlobFeed;
+            PreparePublishFilesToAzureBlobFeed">
     <Message Importance="High" Text="Complete!" />
   </Target>
 

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -61,7 +61,25 @@
 
       <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
       <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
+
+      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'=='true'">$(ProductionVersion)</ProductVersionTxtContents>
+      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'!='true'">$(ProductVersion)</ProductVersionTxtContents>
+
     </PropertyGroup>
+
+    <!-- Generate windowsdesktop-productVersion.txt containing the value of $(PackageVersion) -->
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)windowsdesktop-productVersion.txt"
+      Lines="$(ProductVersionTxtContents)"
+      Overwrite="true"
+      Encoding="ASCII" />
+
+    <!-- Generate productVersion.txt containing the value of $(PackageVersion) -->
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)productVersion.txt"
+      Lines="$(ProductVersionTxtContents)"
+      Overwrite="true"
+      Encoding="ASCII" />
 
     <ItemGroup>
       <ItemsToPush Remove="@(ItemsToPush)" />
@@ -82,6 +100,15 @@
         <Category>Checksum</Category>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
+
+      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)windowsdesktop-productVersion.txt">
+        <RelativeBlobPath>$(InstallersRelativePath)windowsdesktop-productVersion.txt</RelativeBlobPath>
+      </ItemsToPush>
+
+      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
+        <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
+      </ItemsToPush>
+      
     </ItemGroup>
 
     <!--
@@ -125,67 +152,13 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       IsStableBuild="$(IsStableBuild)"
+      PublishFlatContainer="true"
       AssetManifestPath="$(AssetManifestFile)"
       PublishingVersion="3" />
 
     <!-- Copy the generated manifest to the build's artifacts -->
     <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
 
-    <Message Importance="High" Text="Uploading $(AssetManifestFilename) to pipeline" />
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDir)$(AssetManifestFilename)"
-      Importance="High" />
-  </Target>
-
-    <Target Name="PreparePublishFilesToAzureBlobFeed"
-          DependsOnTargets="GetProductVersions">
-    <PropertyGroup>
-
-      <AssetManifestFilename>Manifest.xml</AssetManifestFilename>
-      <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>
-
-      <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
-      <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
-
-      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'=='true'">$(ProductionVersion)</ProductVersionTxtContents>
-      <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'!='true'">$(ProductVersion)</ProductVersionTxtContents>
-
-    </PropertyGroup>
-
-    <!-- Generate windowsdesktop-productVersion.txt containing the value of $(PackageVersion) -->
-    <WriteLinesToFile
-      File="$(ArtifactsShippingPackagesDir)windowsdesktop-productVersion.txt"
-      Lines="$(ProductVersionTxtContents)"
-      Overwrite="true"
-      Encoding="ASCII" />
-
-    <ItemGroup>
-      <ItemsToPush Remove="@(ItemsToPush)" />
-
-      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)windowsdesktop-productVersion.txt">
-        <RelativeBlobPath>$(InstallersRelativePath)windowsdesktop-productVersion.txt</RelativeBlobPath>
-      </ItemsToPush>
-
-    </ItemGroup>
-
-    <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
-    <PushToAzureDevOpsArtifacts
-      ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="@(ManifestBuildData)"
-      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
-      ManifestBranch="$(BUILD_SOURCEBRANCH)"
-      ManifestBuildId="$(BUILD_BUILDNUMBER)"
-      ManifestCommit="$(BUILD_SOURCEVERSION)"
-      IsStableBuild="$(IsStableBuild)"
-      PublishFlatContainer="true"
-      AssetManifestPath="$(AssetManifestFile)"
-      AssetsTemporaryDirectory="$(TempWorkingDir)" />
-    <!-- Copy the generated manifest to the build's artifacts -->
-    <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
-    <Message Importance="High" Text="Uploading $(AssetManifestFilename) to pipeline" />
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDir)$(AssetManifestFilename)"
-      Importance="High" />
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -197,8 +170,7 @@
   <Target Name="Build"
           DependsOnTargets="
             UploadPreparedArtifactsToPipeline;
-            PreparePublishToAzureBlobFeed;
-            PreparePublishFilesToAzureBlobFeed">
+            PreparePublishToAzureBlobFeed">
     <Message Importance="High" Text="Complete!" />
   </Target>
 

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -103,10 +103,12 @@
 
       <ItemsToPush Include="$(ArtifactsShippingPackagesDir)windowsdesktop-productVersion.txt">
         <RelativeBlobPath>$(InstallersRelativePath)windowsdesktop-productVersion.txt</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
 
       <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
         <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
       
     </ItemGroup>
@@ -152,7 +154,6 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       IsStableBuild="$(IsStableBuild)"
-      PublishFlatContainer="true"
       AssetManifestPath="$(AssetManifestFile)"
       PublishingVersion="3" />
 


### PR DESCRIPTION
 Generate windowsdesktop-productVersion.txt containing the product version.  

Fixes https://github.com/dotnet/windowsdesktop/issues/776.

@mmitche:  Can you confirm this is sufficient?