### PR TITLE
Switch to 1ES servicing pools on release/5.0

### DIFF
--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -7,8 +7,8 @@ jobs:
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    name: NetCoreInternal-Pool
-    queue: buildpool.windows.10.amd64.vs2019
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals build.windows.10.amd64.vs2019
   # Double the default timeout.
   timeoutInMinutes: 120
   workspace:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -14,11 +14,11 @@ jobs:
     pool:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2019.open
+        name: NetCore1ESPool-Svc-Public
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2019
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
Same as https://github.com/dotnet/windowsdesktop/pull/2147 but for `release/5.0`.