### PR TITLE
Switch to 1ES R&D pools on main

### DIFF
--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -7,8 +7,8 @@ jobs:
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    name: NetCoreInternal-Pool
-    queue: buildpool.windows.10.amd64.vs2019
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals build.windows.10.amd64.vs2019
   # Double the default timeout.
   timeoutInMinutes: 120
   workspace:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -14,10 +14,10 @@ jobs:
     pool:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Svc-Public
+        name: NetCore1ESPool-Public
         demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Svc-Internal
+        name: NetCore1ESPool-Internal
         demands: ImageOverride -equals build.windows.10.amd64.vs2019
     strategy:
       matrix: 

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -14,11 +14,11 @@ jobs:
     pool:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2019.open
+        name: NetCore1ESPool-Svc-Public
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2019
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
Switching to 1ES R&D pools per https://github.com/dotnet/core-eng/issues/14276.