### PR TITLE
Run API compat for servicing releases

### DIFF
--- a/eng/ApiCompat/ApiCompat.targets
+++ b/eng/ApiCompat/ApiCompat.targets
@@ -1,0 +1,131 @@
+<Project>
+
+  <PropertyGroup>
+    <_BaselineMajorMinorVersion>$(MajorVersion).$(MinorVersion)</_BaselineMajorMinorVersion>
+    <_BaselineFullVersion>$(_BaselineMajorMinorVersion).0</_BaselineFullVersion>
+
+    <_ApiCompatMarkerFile>$(IntermediateOutputPath)marker.txt</_ApiCompatMarkerFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="$(MicrosoftDotNetApiCompatVersion)" IsImplicitlyDefined="true" />
+
+      <!-- 
+        We can't reference the ref packs, as we'd be introducing circular references and breaking other checks.
+        Instead we have to download these with PackageDownload. Unfortunately doing so, we don't have the convenience of 'GeneratePathProperty'
+        and have to generate path manually.
+      -->
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(_BaselineFullVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[$(_BaselineFullVersion)]" />
+    <PackageDownload Include="Microsoft.WindowsDesktop.App.Ref" Version="[$(_BaselineFullVersion)]" />
+  </ItemGroup>
+
+  <Target Name="_GetApiCompatInputsAndOutputs">
+    <PropertyGroup>
+      <_PkgMicrosoft_NETCore_App_Ref>$([MSBuild]::NormalizeDirectory('$(NUGET_PACKAGES)', 'microsoft.netcore.app.ref', $(_BaselineFullVersion)))</_PkgMicrosoft_NETCore_App_Ref>
+      <_PkgMicrosoft_NETCore_App_Runtime_win_x64>$([MSBuild]::NormalizeDirectory('$(NUGET_PACKAGES)', 'microsoft.netcore.app.runtime.win-x64', $(_BaselineFullVersion)))</_PkgMicrosoft_NETCore_App_Runtime_win_x64>
+      <_PkgMicrosoft_WindowsDesktop_App_Ref>$([MSBuild]::NormalizeDirectory('$(NUGET_PACKAGES)', 'microsoft.windowsdesktop.app.ref', $(_BaselineFullVersion)))</_PkgMicrosoft_WindowsDesktop_App_Ref>
+
+      <_NETCoreAppRefPath>$([MSBuild]::NormalizeDirectory('$(_PkgMicrosoft_NETCore_App_Ref)', 'ref', 'net$(_BaselineMajorMinorVersion)'))</_NETCoreAppRefPath>
+      <_WindowsDesktopRefPath>$([MSBuild]::NormalizeDirectory('$(_PkgMicrosoft_WindowsDesktop_App_Ref)', 'ref', 'net$(_BaselineMajorMinorVersion)'))</_WindowsDesktopRefPath>
+      <_NETCoreAppRuntimePath>$([MSBuild]::NormalizeDirectory('$(_PkgMicrosoft_NETCore_App_Runtime_win_x64)', 'runtimes', 'win-x64', 'lib', 'net$(_BaselineMajorMinorVersion)'))</_NETCoreAppRuntimePath>
+
+      <_WindowsFormsRefsPath>$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_Private_Winforms)', 'ref', 'net$(_BaselineMajorMinorVersion)'))</_WindowsFormsRefsPath>
+      <_WindowsFormsApiCompatBaselineIgnoreFile>$(MSBuildThisFileDirectory)baseline.net$(_BaselineMajorMinorVersion).winforms.txt</_WindowsFormsApiCompatBaselineIgnoreFile>
+      <_WpfApiCompatBaselineIgnoreFile>$(MSBuildThisFileDirectory)baseline.net$(_BaselineMajorMinorVersion).wpf.txt</_WpfApiCompatBaselineIgnoreFile>
+    </PropertyGroup>
+
+    <Error Text="Windows Forms ref assemblies cannot be found. Expected under '$(_WindowsFormsRefsPath)'."
+           Condition="!Exists('$(_WindowsFormsRefsPath)')"/>
+    <Error Text="Windows Forms API compat baseline for net$(_BaselineMajorMinorVersion) must be created and stored in '$(_WindowsFormsApiCompatBaselineIgnoreFile)'."
+           Condition="!Exists('$(_WindowsFormsApiCompatBaselineIgnoreFile)') and '$(CreateBaseline)' != 'true'"/>
+    <!-- TODO: WPF team to enable and review
+       <Error Text="WPF API compat baseline for net$(_BaselineMajorMinorVersion) must be created and stored in '$(_WpfApiCompatBaselineIgnoreFile)'."
+           Condition="!Exists('$(_WpfApiCompatBaselineIgnoreFile)') and '$(CreateBaseline)' != 'true'"/> -->
+
+    <ItemGroup>
+      <_DependencyDirectories Include="$(_NETCoreAppRefPath)" />
+      <_DependencyDirectories Include="$(_WindowsDesktopRefPath)" />
+      <_ContractDependencyDirectories Include="$(_NETCoreAppRuntimePath)" />
+
+      <!-- Get the list of Windows Forms ref assemblies shipped in the transport package -->
+      <_WindowsFormsFilePaths Include="$(_WindowsFormsRefsPath)%(FrameworkListFileClass.Identity)"
+                              Condition="'%(FrameworkListFileClass.Profile)' == 'WindowsForms'" />
+      <_WindowsFormsFilePaths Remove="@(_WindowsFormsFilePaths)"
+                              Condition="!Exists(%(Identity))" />
+
+      <!-- Get the list of WPF assemblies that form the Ref surface, i.e. go into <dotnet>\packs\Microsoft.WindowsDesktop.App.Ref\<version>\ref folder -->
+      <_WpfFilePaths Include="$(OutputPath)%(FrameworkListFileClass.Identity)"
+                              Condition="'%(FrameworkListFileClass.Profile)' == 'WPF'" />
+    </ItemGroup>
+
+    <!-- Validate paths for the collected items -->
+    <Error Text="One ofthe required contract dependencies directories is invalid."
+           Condition="!Exists('%(_ContractDependencyDirectories.FullPath)')"/>
+    <Error Text="One ofthe required implementation directories is invalid."
+           Condition="!Exists('%(_DependencyDirectories.FullPath)')"/>
+    <Error Text="Some of Windows Forms assemblies referenced in 'FrameworkListFileClass' group can't be found."
+           Condition="!Exists('%(_WindowsFormsFilePaths.FullPath)')"/>
+
+    <PropertyGroup>
+      <_WindowsFormsApiCompatArgs>"@(_WindowsFormsFilePaths, ',')"</_WindowsFormsApiCompatArgs>
+      <_WindowsFormsApiCompatArgs>$(_WindowsFormsApiCompatArgs) --contract-depends "$(OutputPath),@(_ContractDependencyDirectories, ','),"</_WindowsFormsApiCompatArgs>
+      <_WindowsFormsApiCompatArgs>$(_WindowsFormsApiCompatArgs) --impl-dirs "@(_DependencyDirectories, ','),"</_WindowsFormsApiCompatArgs>
+      <_WindowsFormsApiCompatArgs Condition="'$(CreateBaseline)' != 'true'">$(_WindowsFormsApiCompatArgs) --baseline "$(_WindowsFormsApiCompatBaselineIgnoreFile)"</_WindowsFormsApiCompatArgs>
+      <_WindowsFormsApiCompatArgs>$(_WindowsFormsApiCompatArgs) --ignore-design-time-facades</_WindowsFormsApiCompatArgs>
+
+      <_WindowsFormsCreateBaselineArgs Condition="'$(CreateBaseline)' == 'true'"> &gt; "$(_WindowsFormsApiCompatBaselineIgnoreFile)"</_WindowsFormsCreateBaselineArgs>
+
+      <_WindowsFormsApiCompatResponseFile>$(IntermediateOutputPath)apicompat.winforms.rsp</_WindowsFormsApiCompatResponseFile>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <_WpfApiCompatArgs>"@(_WpfFilePaths, ',')"</_WpfApiCompatArgs>
+      <_WpfApiCompatArgs>$(_WpfApiCompatArgs) --contract-depends "$(OutputPath),@(_ContractDependencyDirectories, ','),"</_WpfApiCompatArgs>
+      <_WpfApiCompatArgs>$(_WpfApiCompatArgs) --impl-dirs "@(_DependencyDirectories, ','),"</_WpfApiCompatArgs>
+      <_WpfApiCompatArgs Condition="'$(CreateBaseline)' != 'true'">$(_WindowsFormsApiCompatArgs) --baseline "$(_WpfApiCompatBaselineIgnoreFile)"</_WpfApiCompatArgs>
+      <_WpfCreateBaselineArgs Condition="'$(CreateBaseline)' == 'true'"> &gt; "$(_WpfApiCompatBaselineIgnoreFile)"</_WpfCreateBaselineArgs>
+
+      <_WpfApiCompatResponseFile>$(IntermediateOutputPath)apicompat.wpf.rsp</_WpfApiCompatResponseFile>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <WriteLinesToFile File="$(_WindowsFormsApiCompatResponseFile)" Lines="$(_WindowsFormsApiCompatArgs)" Overwrite="true" />
+    <WriteLinesToFile File="$(_WpfApiCompatResponseFile)" Lines="$(_WpfApiCompatArgs)" Overwrite="true" />
+  </Target>
+
+  <!--
+    Validate that the current servicing release retains the same public API surface as the first official release.
+  -->
+  <Target Name="EnsureApiCompat"
+          DependsOnTargets="_GetApiCompatInputsAndOutputs"
+          AfterTargets="Build"
+          Inputs="$(_WindowsFormsApiCompatBaselineIgnoreFile);$(_WpfApiCompatBaselineIgnoreFile)"
+          Outputs="$(_ApiCompatMarkerFile)"
+          Condition="'$(RunApiCompat)' == 'true'">
+
+    <Exec Command="$(_ApiCompatCommand) @&quot;$(_WindowsFormsApiCompatResponseFile)&quot; $(_WindowsFormsCreateBaselineArgs)"
+          CustomErrorRegularExpression="^[a-zA-Z]+ :"
+          StandardOutputImportance="Low"
+          IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="WindowsFormsApiCompatExitCode" />
+    </Exec>
+    <Error Condition="'$(WindowsFormsApiCompatExitCode)' != '0'" Text="Windows Forms ApiCompat failed comparing $(_BaselineMajorMinorVersion).$(PatchVersion) to $(_BaselineFullVersion)" />
+
+    <!-- TODO: WPF team to enable and review
+    
+       <Exec Command="$(_ApiCompatCommand) @&quot;$(_WpfApiCompatResponseFile)&quot; $(_WpfCreateBaselineArgs)"
+          CustomErrorRegularExpression="^[a-zA-Z]+ :"
+          StandardOutputImportance="Low"
+          IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="WpfApiCompatExitCode" />
+    </Exec>
+    <Error Condition="'$(WpfApiCompatExitCode)' != '0'" Text="WPF ApiCompat failed comparing $(_BaselineMajorMinorVersion).$(PatchVersion) to $(_BaselineFullVersion)" /> -->
+
+    <!-- Create a marker file which serves as the target's output to enable incremental builds. -->
+    <Touch Files="$(_ApiCompatMarkerFile)"
+           AlwaysCreate="true" />
+ 
+  </Target>
+
+</Project>

--- a/eng/ApiCompat/baseline.net6.0.winforms.txt
+++ b/eng/ApiCompat/baseline.net6.0.winforms.txt
@@ -1,0 +1,1 @@
+Total Issues: 0

--- a/eng/ApiCompat/readme.md
+++ b/eng/ApiCompat/readme.md
@@ -1,0 +1,29 @@
+APICompat is only for servicing releases (PreReleaseVersionLabel=servicing && PatchVersion>0) between the serviced ref-pack and GA's ref pack to protect us from accidentally exposing new API in servicing.
+
+## How it all hangs together
+
+During the build we download the following GA ref packs (i.e., targeting 6.0.0, 7.0.0, etc.):
+* Microsoft.NETCore.App.Ref
+* Microsoft.WindowsDesktop.App.Ref
+* Microsoft.NETCore.App.Runtime.win-x64
+
+After that we resolve ref assemblies that form Windows Desktop SDK (those part of `FrameworkListFileClass` collection) and are shipped in the Windows Forms and WPF transport packages (i.e., Microsoft.Private.Winforms and Microsoft.DotNet.Wpf.GitHub respectvely).
+
+Then we compose APICompat tool command line args and write those into `apicompat.winforms.rsp` and `apicompat.wpf.rsp`, and run the tool for the Windows Forms ref assemblies and then for the WPF ref assemblies, e.g.:
+```
+dotnet.exe .\.packages\microsoft.dotnet.apicompat\6.0.0-beta.21609.4\tools\netcoreapp3.1\Microsoft.DotNet.ApiCompat.dll @".\artifacts\obj\Microsoft.WindowsDesktop.App.Ref\Release\net6.0\win-x64\apicompat.winforms.rsp"
+```
+
+If there are any API discrepancies - the build will fail.
+
+## For new servicing release
+
+For the first servicing release the build will fail with the following error:
+
+> _Windows Forms API compat baseline for net6.0 must be created and stored in '.\eng\ApiCompat\baseline.net6.0.winforms.txt'_
+
+To create a new baseline (and confirm it is expected) run a build with the following argument:
+
+```
+.\build.cmd -c Release /p:CreateBaseline=true
+```

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,6 +21,9 @@
     <NETCoreAppFramework>net$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
     <MicrosoftDotnetWinFormsProjectTemplatesVersion>6.0.1-servicing.21567.5</MicrosoftDotnetWinFormsProjectTemplatesVersion>
     <MicrosoftDotNetWpfProjectTemplatesVersion>6.0.1-servicing.21567.7</MicrosoftDotNetWpfProjectTemplatesVersion>
+
+    <!-- Run APICompat only for the ref pack and only in servicing releases -->
+    <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>
   <!--
 
@@ -49,6 +52,7 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- arcade -->
+    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.21609.4</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21609.4</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.21609.4</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21609.4</MicrosoftDotNetBuildTasksPackagingVersion>
@@ -56,7 +60,7 @@
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.21609.4</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- runtime -->
     <MicrosoftNETCoreAppRefVersion>6.0.1</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>6.0.1</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCoreAppRuntimewinx64Version>$(MicrosoftNETCoreAppRefVersion)</MicrosoftNETCoreAppRuntimewinx64Version>
     <MicrosoftInternalRuntimeWindowsDesktopTransportVersion>6.0.1-servicing.21567.5</MicrosoftInternalRuntimeWindowsDesktopTransportVersion>
     <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.1-servicing.21567.5</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
     <!-- winforms -->

--- a/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
+++ b/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
@@ -7,7 +7,9 @@
     <InstallerName>windowsdesktop-targeting-pack</InstallerName>
     <InstallerRuntimeIdentifiers>win-x64;win-x86;win-arm64</InstallerRuntimeIdentifiers>
     <VSInsertionShortComponentName>WindowsDesktop.TargetingPack</VSInsertionShortComponentName>
+
     <CreatePlatformManifest Condition="'$(PreReleaseVersionLabel)' == 'servicing'">false</CreatePlatformManifest>
+    <RunApiCompat Condition=" '$(PreReleaseVersionLabel)' == 'servicing' and $(PatchVersion) &gt; 0">true</RunApiCompat>
   </PropertyGroup>
 
   <!-- 
@@ -76,4 +78,7 @@
   <ItemGroup Condition="'$(CreatePlatformManifest)' == 'false'">
     <FilesToPackage  Include="PlatformManifest.txt" TargetPath="data" GeneratedBuildFile="true" />
   </ItemGroup>
+
+  <!-- Windows Forms validation and packaging -->
+  <Import Project="$(RepositoryEngineeringDir)ApiCompat\ApiCompat.targets" />
 </Project>


### PR DESCRIPTION
Inspired by https://github.com/dotnet/windowsdesktop/pull/2362#issuecomment-982923789
For the background refer to dotnet/aspnetcore#39471.

API compat specific:
1. No API compat is run for non-servicing releases or base servicing releases (i.e. `PatchVersion=0`)
2. Error is emitted if there is no baseline file between the base servicing release and the current release.
3. Error is emitted if any of "FrameworkListFileClass" assemblies are missing.
4. A new baseline can be created by passing `/p:CreateBaseline=true` argument, e.g. `.\eng\common\CIBuild.cmd -c Release /p:CreateBaseline=true`.

Note: WPF is currently disabled.