### PR TITLE
Always build ref packs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,23 +21,7 @@
     <MicrosoftDotnetWinFormsProjectTemplatesVersion>7.0.0-alpha.1.22070.2</MicrosoftDotnetWinFormsProjectTemplatesVersion>
     <MicrosoftDotNetWpfProjectTemplatesVersion>7.0.0-preview.1.22072.1</MicrosoftDotNetWpfProjectTemplatesVersion>
   </PropertyGroup>
-  <!--
-    Servicing build settings for setup packages. Instructions:
 
-    * To enable a package build for the current patch release, set PatchVersion to match the current
-      patch version of that package. ("major.minor.patch".) This is normally the same as
-      PatchVersion above.
-    * When the PatchVersion property above is incremented at the beginning of the next servicing
-      release, all packages listed below automatically stop building because the property no longer
-      matches the metadata. (Do not delete the items!)
-
-    If the PatchVersion below is never changed from '0', the package will build in the 'master'
-    branch, and during a forked RTM release ("X.Y.0"). It will stop building for "X.Y.1" unless
-    manually enabled by updating the metadata.
-  -->
-  <ItemGroup>
-    <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />
-  </ItemGroup>
   <!--Package versions-->
   <PropertyGroup>
     <!-- arcade -->


### PR DESCRIPTION
For the background refer to https://github.com/dotnet/aspnetcore/issues/39471.

This was already done in release/6.0 branch, this is just making sure we have it in main so that in future servicing branches this is already taken care of.