### PR TITLE
Always build ref packs

### DIFF
--- a/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
+++ b/pkg/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
@@ -7,6 +7,7 @@
     <InstallerName>windowsdesktop-targeting-pack</InstallerName>
     <InstallerRuntimeIdentifiers>win-x64;win-x86;win-arm64</InstallerRuntimeIdentifiers>
     <VSInsertionShortComponentName>WindowsDesktop.TargetingPack</VSInsertionShortComponentName>
+    <CreatePlatformManifest Condition="'$(PreReleaseVersionLabel)' == 'servicing'">false</CreatePlatformManifest>
   </PropertyGroup>
 
   <!-- 
@@ -72,4 +73,7 @@
   <!-- Windows Forms validation and packaging -->
   <Import Project="WindowsForms.Packaging.targets" />
 
+  <ItemGroup Condition="'$(CreatePlatformManifest)' == 'false'">
+    <FilesToPackage Include="PlatformManifest.txt" TargetPath="data" GeneratedBuildFile="true" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Forwardporting from https://github.com/dotnet/windowsdesktop/pull/2362, so we don't miss this in 7.0.x servicing.