### PR TITLE
Re-add inbuild signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -6,6 +6,7 @@
       here and rely on overall signing validation.
     -->
     <AllowEmptySignList Condition="'$(SignFinalPackages)' != 'true'">true</AllowEmptySignList>
+    <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,10 +15,6 @@
     <ItemsToSign Remove="@(ItemsToSign)" />
     <ItemsToSignPostBuild Remove="@(ItemsToSignPostBuild)" />
 
-    <!-- Find bundle artifacts, which need multiple stages to fully sign. -->
-    <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
-    <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
-
     <!-- apphost and comhost template files are not signed, by design. -->
     <FileSignInfo Include="apphost.exe;comhost.dll" CertificateName="None" />
 
@@ -27,8 +23,8 @@
     <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
   </ItemGroup>
 
-  <!-- When doing post build signing, we sign all artifacts we would push.
-        Symbol packages are included too. -->
+  <!-- This repo signs everything, including installers, either right before doing the PushToAzureDevOpsArtifacts,
+       or in post-build. Populate what will get signed the same in both cases -->
   <ItemGroup Condition="'$(PrepareArtifacts)' == 'true'">
     <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.msi" />
     <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.exe" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -27,56 +27,17 @@
     <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
   </ItemGroup>
 
-  <Choose>
-    <When Condition="'$(PostBuildSign)' != 'true'">
-      <ItemGroup Condition="'$(SignBinaries)' == 'true'">
-        <ItemsToSign Include="$(CrossGenRootPath)**/*.dll" />
-      </ItemGroup>
+  <!-- When doing post build signing, we sign all artifacts we would push.
+        Symbol packages are included too. -->
+  <ItemGroup Condition="'$(PrepareArtifacts)' == 'true'">
+    <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.msi" />
+    <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.exe" />
+    <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.nupkg" />
+    <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.zip" />
 
-      <ItemGroup Condition="'$(SignMsiFiles)' == 'true'">
-        <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.msi" />
-        <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.cab" />
-      </ItemGroup>
-
-      <ItemGroup Condition="'$(SignBurnEngineFiles)' == 'true'">
-        <ItemsToSign Include="@(BundleInstallerEngineArtifact)" />
-      </ItemGroup>
-
-      <ItemGroup Condition="'$(SignBurnBundleFiles)' == 'true'">
-        <!-- Sign the bundles, now that the engine is reattached. Avoid re-signing the engine. -->
-        <ItemsToSign
-          Include="@(BundleInstallerExeArtifact)"
-          Exclude="@(BundleInstallerEngineArtifact)" />
-        <!-- Note: wixstdba is internal to the engine bundle and does not get signed. -->
-      </ItemGroup>
-
-      <ItemGroup Condition="'$(SignFinalPackages)' == 'true'">
-        <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
-        <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
-
-        <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
-        <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
-      </ItemGroup>
-
-      <ItemGroup>
-        <!-- External files -->
-        <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
-      </ItemGroup>
-    </When>
-
-    <!-- When doing post build signing, we sign all artifacts we would push.
-         Symbol packages are included too. -->
-    <When Condition="'$(PostBuildSign)' == 'true'">
-      <ItemGroup>
-        <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.msi" Condition="'$(PrepareArtifacts)' == 'true'" />
-        <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.exe" Condition="'$(PrepareArtifacts)' == 'true'" />
-        <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.nupkg" Condition="'$(PrepareArtifacts)' == 'true'" />
-        <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.zip" Condition="'$(PrepareArtifacts)' == 'true'" />
-
-        <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
-        <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" />
-      </ItemGroup>
-    </When>
-  </Choose>
+    <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
+    <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" Condition="'$(PostBuildSign)' == 'true'" />
+    <ItemsToSign Include="@(ItemsToSignWithPaths->Distinct())" Condition="'$(PostBuildSign)' != 'true'" />
+  </ItemGroup>
 
 </Project>

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -52,8 +52,20 @@
       Importance="High" />
   </Target>
 
+  <!--
+    Run Arcade's signing project directly, since this project doesn't use the arcade SDK.
+  -->
+  <Target Name="SignArtifacts" Condition="'$(PostBuildSign)' != 'true'">
+    <MSBuild
+      Projects="$(ArcadeSdkSignProject)"
+      Targets="Sign"
+      Properties="
+        DownloadDirectory=$(DownloadDirectory);
+        PrepareArtifacts=$(PrepareArtifacts)" />
+  </Target>
+
   <Target Name="PreparePublishToAzureBlobFeed"
-          DependsOnTargets="GetProductVersions;FindDownloadedArtifacts">
+          DependsOnTargets="GetProductVersions;FindDownloadedArtifacts;SignArtifacts">
 
     <PropertyGroup>
       <AssetManifestFilename>Manifest.xml</AssetManifestFilename>


### PR DESCRIPTION
This re-enables inbuild signing. Unlike the previous iteration of inbuild signing we now can use the same approach for dealing with containers as we do with post-build signing (sign wixpacks, repack them, iteratively). Essentially a way to think of this is that we are doing post-build signing, but it happens to be in-build.

To do so, a target is added in the prepare-artifacts project that calls the arcade sign project (windowsdesktop doesn't really use the standard arcade process).