### PR TITLE
Fix TFM and help publishing succeed.

### DIFF
--- a/tools-local/tasks/local.tasks.csproj
+++ b/tools-local/tasks/local.tasks.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>$(TargetFrameworks);net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(RunningOnUnix)' != 'true'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <ProjectGuid>{360F25FA-3CD9-4338-B961-A4F3122B88B2}</ProjectGuid>
     <OutputPath>$(LocalBuildToolsDir)</OutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
@@ -17,24 +16,12 @@
   <ItemGroup>
     <PackageReference Include="NuGet.ProjectModel" Version="$(NugetProjectModelVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
 
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Tasks.v4.0" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It seems we no longer need Framework target here. Curtesy: @mmitche .

We have publishing step failing since we last updated TFM for compliance reasons.

Related to #3099.

Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=1948262&view=results
