### PR TITLE
[release/7.0] Remove VS nupkg push

### DIFF
--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -90,20 +90,6 @@ jobs:
         parameters:
           name: Generate_SBOM_${{ parameters.name }}
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: NuGetCommand@2
-        displayName: Push Visual Studio NuPkgs
-        inputs:
-          command: push
-          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
-          nuGetFeedType: external
-          publishFeedCredentials: 'DevDiv - VS package feed'
-        condition: and(
-          succeeded(),
-          eq(variables['_BuildConfig'], 'Release'),
-          ne(variables['DisableVSPublish'], 'true'),
-          ne(variables['PostBuildSign'], 'true'))
-
     - template: steps/upload-job-artifacts.yml
       parameters:
         name: ${{ parameters.name }}


### PR DESCRIPTION
Signing happens at the end of the build now, even with in-build signing. The staging pipeline pushes the nupkgs. This step is not necessary, and pushes unsigned nupkgs.