### PR TITLE
Update internal build image

### DIFF
--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -17,7 +17,7 @@ jobs:
         vmImage: 'windows-2019'
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals build.windows.10.amd64.vs2019
+        demands: ImageOverride -equals windows.vs2019.amd64
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
The `build.windows.10.amd64.vs2019` image doesn't exist anymore, it was replaced by `windows.vs2019.amd64`