### PR TITLE
Remove explicit source build packagerefs

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -3,10 +3,6 @@
   <!-- excluded from source build -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksVersion)" />
-
-    <!-- SourceLink -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(MicrosoftSourceLinkAzureReposGitVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This repository doesn't use pkgprojs anymore. Does anyone know what the remaining `Microsoft.DotNet.VersionTools.Tasks` dependency is for?