### PR TITLE
Move Microsoft.Windows.Compatibility into windowsdesktop

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
   <ItemGroup>
+    <!-- Microsoft.WindowsDesktop.App shared framework -->
     <ProjectReference Include="src\windowsdesktop\src\sfx\**\*.sfxproj" />
     <ProjectReference Include="src\windowsdesktop\src\bundle\**\*.bundleproj" />
     <ProjectReference Include="src\windowsdesktop\tests\**\*.Tests.csproj" />
+
+    <!-- Microsoft.Windows.Compatibility nuget meta package -->
+    <ProjectReference Include="src\Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,9 +16,6 @@
     <PackageThirdPartyNoticesFile>$(MSBuildThisFileDirectory)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</PackageReleaseNotes>
 
-    <!-- Floating TFM which is defined in Arcade -->
-    <TargetFramework>$(NetCurrent)</TargetFramework>
-
     <!-- Set up handling of build warnings -->
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -37,6 +37,118 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>08940fbba6aed7b0edafb00914691035cf71cc7d</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.CodeDom" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.ComponentModel.Composition" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Data.Odbc" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Data.OleDb" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices.AccountManagement" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices.Protocols" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Ports" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Management" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Reflection.Context" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.ServiceModel.Syndication" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Speech" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Threading.AccessControl" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.ComponentModel.Composition.Registration" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
+    </Dependency>
+    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.4.23172.4" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/winforms</Uri>
+      <Sha>f777662b7d00d81e52255e3c3b699f401eaaea6c</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23174.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -37,115 +37,115 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>599cce2fff315dd2c6d712436e890837cdc3ff3e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.CodeDom" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Composition" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.ComponentModel.Composition" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Data.Odbc" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Data.Odbc" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Data.OleDb" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Data.OleDb" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices.AccountManagement" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.DirectoryServices.AccountManagement" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices.Protocols" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.DirectoryServices.Protocols" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Ports" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.IO.Ports" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Management" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Management" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Context" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Reflection.Context" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceModel.Syndication" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.ServiceModel.Syndication" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Speech" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Speech" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Threading.AccessControl" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Composition.Registration" Version="8.0.0-preview.4.23172.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.ComponentModel.Composition.Registration" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7500625bd9303a48d0500b6123cec604e49039ae</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.4.23172.4" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.4.23177.3" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>f777662b7d00d81e52255e3c3b699f401eaaea6c</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,4 +1,5 @@
 <Project>
+
   <PropertyGroup>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
@@ -9,25 +10,68 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
-  <!--Package versions-->
+
   <PropertyGroup>
     <!-- arcade -->
     <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.23174.1</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>8.0.0-beta.23174.1</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>8.0.0-beta.23174.1</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>8.0.0-beta.23174.1</MicrosoftDotNetVersionToolsTasksVersion>
+    <!-- corefx -->
+    <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>
+    <SystemDataSqlClientVersion>4.8.5</SystemDataSqlClientVersion>
+    <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
+    <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
+    <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
+    <!-- nuget -->
+    <NugetPackagingVersion>4.9.4</NugetPackagingVersion>
     <!-- runtime -->
+    <MicrosoftInternalRuntimeWindowsDesktopTransportVersion>8.0.0-preview.4.23172.1</MicrosoftInternalRuntimeWindowsDesktopTransportVersion>
     <MicrosoftNETCoreAppRefVersion>8.0.0-preview.4.23172.1</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>8.0.0-preview.4.23172.1</MicrosoftNETCoreAppRuntimewinx64Version>
-    <MicrosoftInternalRuntimeWindowsDesktopTransportVersion>8.0.0-preview.4.23172.1</MicrosoftInternalRuntimeWindowsDesktopTransportVersion>
+    <MicrosoftWin32RegistryAccessControlVersion>8.0.0-preview.4.23172.1</MicrosoftWin32RegistryAccessControlVersion>
+    <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32SystemEventsVersion>8.0.0-preview.4.23172.1</MicrosoftWin32SystemEventsVersion>
+    <SystemCodeDomVersion>8.0.0-preview.4.23172.1</SystemCodeDomVersion>
+    <SystemComponentModelCompositionRegistrationVersion>8.0.0-preview.4.23172.1</SystemComponentModelCompositionRegistrationVersion>
+    <SystemComponentModelCompositionVersion>8.0.0-preview.4.23172.1</SystemComponentModelCompositionVersion>
+    <SystemConfigurationConfigurationManagerVersion>8.0.0-preview.4.23172.1</SystemConfigurationConfigurationManagerVersion>
+    <SystemDataOdbcVersion>8.0.0-preview.4.23172.1</SystemDataOdbcVersion>
+    <SystemDataOleDbVersion>8.0.0-preview.4.23172.1</SystemDataOleDbVersion>
+    <SystemDiagnosticsEventLogVersion>8.0.0-preview.4.23172.1</SystemDiagnosticsEventLogVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>8.0.0-preview.4.23172.1</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemDirectoryServicesAccountManagementVersion>8.0.0-preview.4.23172.1</SystemDirectoryServicesAccountManagementVersion>
+    <SystemDirectoryServicesProtocolsVersion>8.0.0-preview.4.23172.1</SystemDirectoryServicesProtocolsVersion>
+    <SystemDirectoryServicesVersion>8.0.0-preview.4.23172.1</SystemDirectoryServicesVersion>
+    <SystemIOFileSystemAccessControlVersion>5.0.0</SystemIOFileSystemAccessControlVersion>
+    <SystemIOPackagingVersion>8.0.0-preview.4.23172.1</SystemIOPackagingVersion>
+    <SystemIOPipesAccessControlVersion>5.0.0</SystemIOPipesAccessControlVersion>
+    <SystemIOPortsVersion>8.0.0-preview.4.23172.1</SystemIOPortsVersion>
+    <SystemManagementVersion>8.0.0-preview.4.23172.1</SystemManagementVersion>
+    <SystemReflectionContextVersion>8.0.0-preview.4.23172.1</SystemReflectionContextVersion>
+    <SystemRuntimeCachingVersion>8.0.0-preview.4.23172.1</SystemRuntimeCachingVersion>
+    <SystemSecurityAccessControlVersion>6.0.0</SystemSecurityAccessControlVersion>
+    <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
+    <SystemSecurityCryptographyPkcsVersion>8.0.0-preview.4.23172.1</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyProtectedDataVersion>8.0.0-preview.4.23172.1</SystemSecurityCryptographyProtectedDataVersion>
+    <SystemSecurityCryptographyXmlVersion>8.0.0-preview.4.23172.1</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityPermissionsVersion>8.0.0-preview.4.23172.1</SystemSecurityPermissionsVersion>
+    <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
+    <SystemServiceModelSyndicationVersion>8.0.0-preview.4.23172.1</SystemServiceModelSyndicationVersion>
+    <SystemServiceProcessServiceControllerVersion>8.0.0-preview.4.23172.1</SystemServiceProcessServiceControllerVersion>
+    <SystemSpeechVersion>8.0.0-preview.4.23172.1</SystemSpeechVersion>
+    <SystemTextEncodingCodePagesVersion>8.0.0-preview.4.23172.1</SystemTextEncodingCodePagesVersion>
+    <SystemThreadingAccessControlVersion>8.0.0-preview.4.23172.1</SystemThreadingAccessControlVersion>
     <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-preview.4.23172.1</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
+    <!-- wcf -->
+    <SystemServiceModelVersion>4.10.0</SystemServiceModelVersion>
     <!-- winforms -->
     <MicrosoftDotnetWinFormsProjectTemplatesVersion>8.0.0-preview.4.23172.4</MicrosoftDotnetWinFormsProjectTemplatesVersion>
     <MicrosoftPrivateWinformsVersion>8.0.0-preview.4.23172.4</MicrosoftPrivateWinformsVersion>
+    <SystemDrawingCommonVersion>8.0.0-preview.4.23172.4</SystemDrawingCommonVersion>
     <!-- wpf -->
     <MicrosoftDotNetWpfGitHubVersion>8.0.0-preview.4.23177.1</MicrosoftDotNetWpfGitHubVersion>
     <MicrosoftDotNetWpfProjectTemplatesVersion>8.0.0-preview.4.23177.1</MicrosoftDotNetWpfProjectTemplatesVersion>
-    <!-- Not auto-updated. -->
-    <NugetPackagingVersion>4.9.4</NugetPackagingVersion>
   </PropertyGroup>
+
 </Project>

--- a/global.json
+++ b/global.json
@@ -6,6 +6,6 @@
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23174.1",
     "Microsoft.DotNet.SharedFramework.Sdk": "8.0.0-beta.23174.1",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.Build.Traversal": "3.3.0"
+    "Microsoft.Build.Traversal": "3.4.0"
   }
 }

--- a/src/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -1,0 +1,75 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <PropertyGroup>
+    <!-- Using a csproj extension to get the correct multi-targeting behavior. -->
+    <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum);netstandard2.1;netstandard2.0</TargetFrameworks>
+    <!-- Reference the outputs for the dependency nodes calculation. -->
+    <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
+    <IsPackable>true</IsPackable>
+    <!-- This is a meta package and doesn't contain any libs. -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageDescription>This Windows Compatibility Pack provides access to APIs that were previously available only for .NET Framework. It can be used from both .NET as well as .NET Standard.</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="$(MicrosoftWin32RegistryAccessControlVersion)" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsVersion)" />
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionVersion)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
+    <PackageReference Include="System.Data.Odbc" Version="$(SystemDataOdbcVersion)" />
+    <PackageReference Include="System.Data.OleDb" Version="$(SystemDataOleDbVersion)" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounterVersion)" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="$(SystemDirectoryServicesAccountManagementVersion)" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="$(SystemDirectoryServicesProtocolsVersion)" />
+    <PackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
+    <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
+    <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsVersion)" />
+    <PackageReference Include="System.Management" Version="$(SystemManagementVersion)" />
+    <PackageReference Include="System.Reflection.Context" Version="$(SystemReflectionContextVersion)" />
+    <PackageReference Include="System.Runtime.Caching" Version="$(SystemRuntimeCachingVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
+    <PackageReference Include="System.ServiceModel.Syndication" Version="$(SystemServiceModelSyndicationVersion)" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="$(SystemServiceProcessServiceControllerVersion)" />
+    <PackageReference Include="System.Speech" Version="$(SystemSpeechVersion)" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
+    <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />  
+    <PackageReference Include="System.ServiceModel.Duplex;
+                               System.ServiceModel.Http;
+                               System.ServiceModel.NetTcp;
+                               System.ServiceModel.Primitives;
+                               System.ServiceModel.Security;
+                               System.Web.Services.Description"
+                      Version="$(SystemServiceModelVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
+    <PackageReference Include="System.ComponentModel.Composition.Registration" Version="$(SystemComponentModelCompositionRegistrationVersion)" />
+  </ItemGroup>
+
+  <!-- Packages which are inbox on frameworks newer than .NET Standard 2.0. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="$(SystemReflectionEmitILGenerationVersion)" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightVersion)" />
+  </ItemGroup>
+
+  <!-- Packages which are inbox in NET6 and shouldn't be referenced anymore. -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="$(SystemDataDataSetExtensionsVersion)" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" />
+    <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Windows.Compatibility/src/README.md
+++ b/src/Microsoft.Windows.Compatibility/src/README.md
@@ -1,0 +1,9 @@
+# Microsoft.Windows.Compatibility package
+
+This Windows Compatibility Pack provides access to APIs that were previously available only for .NET Framework. It can be used from both .NET as well as .NET Standard.
+
+### How to add a new dependency
+1. Add the package version to the repository's Versions.props file.
+2. Add the package dependency to the repository's Version.Details.xml file. If the dependency doesn't come from a repository with a direct subscription to (i.e. winforms and runtime), add the `CoherentParentDependency` attribute to the dependency.
+3. Add the package reference into the Microsoft.Windows.Compatibility.csproj file and use the version just defined in the Versions.props file.
+4. If a `CoherentParentDependency` attribute was required, a dependency must be added to the repository dependency chain as well. I.e. to add a new dependency from runtime, a dependency must also be added in winforms and wpf's Version.Details.xml file.

--- a/src/publish/prepare-artifacts.proj
+++ b/src/publish/prepare-artifacts.proj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets" InitialTargets="FindDownloadedArtifacts">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <!-- Set IsStableBuild to mimic https://github.com/dotnet/arcade/blob/694d59f090b743f894779d04a7ffe11cbaf352e7/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj#L30-L31 -->
     <IsStableBuild>false</IsStableBuild>
     <IsStableBuild Condition="'$(DotNetFinalVersionKind)' == 'release'">true</IsStableBuild>

--- a/src/windowsdesktop/src/Directory.Build.props
+++ b/src/windowsdesktop/src/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <ProductBrandPrefix>Microsoft Windows Desktop</ProductBrandPrefix>
     <!-- The Microsoft.WindowsDesktop.App shared framework composition depends on winforms, wpf and runtime transport packages
          which contain architecture agnostic assets. As the OS part of the RID is always the portable "win", we don't need to

--- a/src/windowsdesktop/tests/Microsoft.WindowsDesktop.App.Tests.csproj
+++ b/src/windowsdesktop/tests/Microsoft.WindowsDesktop.App.Tests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Ensure the packaging projects build first. Don't do this in VS: the build takes too long and isn't incremental. -->
     <ProjectReference Include="..\src\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj;


### PR DESCRIPTION
Blocked by https://github.com/dotnet/wpf/pull/7681

Now that System.Drawing.Common is part of winforms, the Microsoft.Windows.Compatibility meta package needs to be moved into a higher layer as runtime can't depend on winforms' product dependencies.

Moving the `TargetFramework` property into the respective project files to allow this repository to have multi-targeting projects.
Also updating the Traversal project which now avoids an unnecessary package dependency on the net45 reference assemblies.

cc @JeremyKuhne 