### PR TITLE
Remove VS nupkg push

### DIFF
--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -84,19 +84,6 @@ jobs:
         parameters:
           name: Generate_SBOM_${{ parameters.name }}
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: NuGetCommand@2
-        displayName: Push Visual Studio NuPkgs
-        inputs:
-          command: push
-          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
-          nuGetFeedType: external
-          publishFeedCredentials: 'DevDiv - VS package feed'
-        condition: and(
-          succeeded(),
-          eq(variables['_BuildConfig'], 'Release'),
-          ne(variables['PostBuildSign'], 'true'))
-
     - template: /eng/pipelines/steps/upload-job-artifacts.yml
       parameters:
         name: ${{ parameters.name }}


### PR DESCRIPTION
VS redist packages are pushed before they are signed resulting in SignCheck failures in VS. We removed similar issues recently in runtime (see https://github.com/dotnet/runtime/pull/84796/files)