### PR TITLE
Enable BinSkim scan in nightly validation

### DIFF
--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,4 +1,5 @@
 -SourceToolsList @("policheck","credscan")
+-ArtifactToolsList @("binskim")
 -TsaInstanceURL https://devdiv.visualstudio.com/
 -TsaProjectName DEVDIV
 -TsaNotificationEmail wffteam@microsoft.com


### PR DESCRIPTION
Enabling BinSkim scan over build artifacts in [Validate-DotNet pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=827) and the .NET staging pipeline based on company requirements.
More information is in the [Automate BinSkim runs over official builds issue](https://github.com/dotnet/arcade-services/issues/2647)  

@andriipatsula will merge this once the change in the pipeline is tested. After the validation pipeline run you can expect a TSA email with some alerts from the BinSkim scan