### PR TITLE
Remove System.Windows.Forms.IgnoredReferences.props From Microsoft.WindowsDesktop.App.Ref.sfxproj

### DIFF
--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
@@ -40,12 +40,6 @@
     -->
   <Import Project="$(PkgMicrosoft_Private_Winforms)\sdk\dotnet-windowsdesktop\System.Windows.Forms.FileClassification.props"
           Condition="Exists('$(PkgMicrosoft_Private_Winforms)')" />
-  <!-- 
-    Windows Forms specific private references to ignore
-    see: https://github.com/dotnet/winforms/tree/main/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop
-    -->
-  <Import Project="$(PkgMicrosoft_Private_Winforms)\sdk\dotnet-windowsdesktop\System.Windows.Forms.IgnoredReferences.props"
-          Condition="Exists('$(PkgMicrosoft_Private_Winforms)')" />
 
   <!-- WPF specific references -->
   <ItemGroup>


### PR DESCRIPTION
This is `.props` file is going to be removed in WinForms so remove the reference to it in Microsoft.WindowsDesktop.App.Ref.sfxproj