### PR TITLE
[release/8.0] Update System.Data.SqlClient

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,7 @@
     <MicrosoftDotNetVersionToolsTasksVersion>8.0.0-beta.24059.4</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- corefx -->
     <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>
-    <SystemDataSqlClientVersion>4.8.5</SystemDataSqlClientVersion>
+    <SystemDataSqlClientVersion>4.8.6</SystemDataSqlClientVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>


### PR DESCRIPTION
## Customer Impact

- [X] Customer reported
- [X] Found internally

Customer notices a CG warning when referencing the latest Microsoft.Windows.Compatibility.

Customers want to get the most up to date dependencies from the Microsoft.Windows.Compatibility and not have to worry about updating transitive dependencies.  

## Regression

- [ ] Yes
- [X] No

## Testing

Build and inspect package.

## Risk

Low - we make these changes regularly.