### PR TITLE
Set metadata for .NET release shipping assets in manifest

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,5 @@
+<Project>
+   <PropertyGroup>
+      <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+   </PropertyGroup>
+</Project>

--- a/src/publish/prepare-artifacts.proj
+++ b/src/publish/prepare-artifacts.proj
@@ -28,7 +28,10 @@
   <PropertyGroup>
     <PrepareArtifacts>true</PrepareArtifacts>
   </PropertyGroup>
+
   <Import Project="../tools/Sign.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <Import Project="$(RepositoryEngineeringDir)Publishing.props" Condition="Exists('$(RepositoryEngineeringDir)Publishing.props')" />
 
   <!-- Since this repo doesn't use publish.proj, update the incoming arcade defaults to use MicrosoftDotNet500 -->
   <ItemGroup>
@@ -48,6 +51,16 @@
         DownloadDirectory=$(DownloadDirectory);
         PrepareArtifacts=$(PrepareArtifacts)" />
   </Target>
+
+  <!-- 
+    Set metadata for assets that are not marked as NonShipping. 
+    This is used to determine if the asset should be shipped as part of .NET release.
+  -->
+  <ItemDefinitionGroup>
+    <ItemsToPush>
+      <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
+    </ItemsToPush>
+  </ItemDefinitionGroup>
 
   <Target Name="PreparePublishToAzureBlobFeed"
           AfterTargets="Build"


### PR DESCRIPTION
Set `DotNetReleaseShipping` metadata for the assets that we ship with the .NET release infra. Based on this property we will select which packages and symbols packages to ship as part of .NET on release day.

- Adding a `Publishing.props` file to configure custom publishing properties 
- setting `ProducesDotNetReleaseShippingAssets` to true as windowsdesktop produces .NET release shipping packages
- adding the metadata to assets in `prepare-artifacts.proj` since the repo doesn't use arcades default publishing

Tracking issue: [Set ProducesNetCoreAssets property for repos that produce .NET packages issue](https://github.com/dotnet/release/issues/822)