### PR TITLE
[release/8.0] Set metadata for .NET release shipping assets in manifest

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,5 @@
+<Project>
+   <PropertyGroup>
+      <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+   </PropertyGroup>
+</Project>

--- a/src/publish/prepare-artifacts.proj
+++ b/src/publish/prepare-artifacts.proj
@@ -28,7 +28,10 @@
   <PropertyGroup>
     <PrepareArtifacts>true</PrepareArtifacts>
   </PropertyGroup>
+
   <Import Project="../tools/Sign.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <Import Project="$(RepositoryEngineeringDir)Publishing.props" Condition="Exists('$(RepositoryEngineeringDir)Publishing.props')" />
 
   <!-- Since this repo doesn't use publish.proj, update the incoming arcade defaults to use MicrosoftDotNet500 -->
   <ItemGroup>
@@ -48,6 +51,16 @@
         DownloadDirectory=$(DownloadDirectory);
         PrepareArtifacts=$(PrepareArtifacts)" />
   </Target>
+
+  <!-- 
+    Set metadata for assets that are not marked as NonShipping. 
+    This is used to determine if the asset should be shipped as part of .NET release.
+  -->
+  <ItemDefinitionGroup>
+    <ItemsToPush>
+      <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
+    </ItemsToPush>
+  </ItemDefinitionGroup>
 
   <Target Name="PreparePublishToAzureBlobFeed"
           AfterTargets="Build"


### PR DESCRIPTION
Backport of https://github.com/dotnet/windowsdesktop/pull/4173 to release/8.0