### PR TITLE
Enable publishing in VMR

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -7,6 +7,7 @@
 
   <!-- Include installer archives and packages which aren't globbed by default. -->
   <Target Name="PublishWindowsDesktopInstallers">
+    <!-- Retrieve windows desktop runtime pack product version. -->
     <MSBuild Projects="$(RepoRoot)src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj"
              Targets="ReturnProductVersion">
       <Output TaskParameter="TargetOutputs" ItemName="WindowsDesktopRuntimePackProductVersion" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -11,8 +11,8 @@
        TODO: This will need to be updated to support arm64.
     -->
     <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)**\*.zip;
-                                   $(ArtifactsPackagesDir)**\*.exe;
-                                   $(ArtifactsPackagesDir)**\*.msi"
+                                    $(ArtifactsPackagesDir)**\*.exe;
+                                    $(ArtifactsPackagesDir)**\*.msi"
                            ManifestArtifactData="NonShipping=false"
                            PublishFlatContainer="true"
                            RelativeBlobPath="WindowsDesktop/$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)/%(Filename)%(Extension)" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,37 @@
 <Project>
-   <PropertyGroup>
-      <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
-   </PropertyGroup>
+
+  <PropertyGroup>
+    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers</PublishDependsOnTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_InstallersToPublish Remove="@(_InstallersToPublish)" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.zip" UploadPathSegment="WindowsDesktop" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.exe" UploadPathSegment="WindowsDesktop" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.msi" UploadPathSegment="WindowsDesktop" Condition="'$(DotNetBuildRepo)' == 'true'" />
+  </ItemGroup>
+
+  <Target Name="_PublishInstallers">
+
+    <ItemGroup>
+      <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows.
+           Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
+           the nupkgs pushed. Do not do this if building from source, since we want the source build intermediate package
+           to be published. Use DotNetBuildRepo as DotNetBuildFromSource is only set in the internal source build,
+           and Build.proj is invoked from the wrapper build. -->
+      <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true' and '$(DotNetBuildRepo)' != 'true'" />
+
+      <!--
+         MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion is x64 version - there is no Rid-specific property.
+         TODO: This will need to be updated to support arm64.
+      -->
+      <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
+        <ManifestArtifactData>NonShipping=false</ManifestArtifactData>
+        <PublishFlatContainer>true</PublishFlatContainer>
+        <RelativeBlobPath>%(_InstallersToPublish.UploadPathSegment)/$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)/%(Filename)%(Extension)</RelativeBlobPath>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
-    <PublishDependsOnTargets Condition="'$(DotNetBuildRepo)' == 'true'">$(PublishDependsOnTargets);PublishWindowsDesktopInstallers</PublishDependsOnTargets>
   </PropertyGroup>
 
   <!-- Include installer archives and packages which aren't globbed by default. -->
-  <Target Name="PublishWindowsDesktopInstallers">
+  <Target Name="PublishWindowsDesktopInstallers"
+          BeforeTargets="BeforePublish;PublishToAzureDevOpsArtifacts"
+          Condition="'$(DotNetBuildRepo)' == 'true'">
     <!-- Retrieve windows desktop runtime pack product version.
          Don't stabilize the package version in order to retrieve the VersionSuffix. -->
     <MSBuild Projects="$(RepoRoot)src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj"

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -16,7 +16,6 @@
                            ManifestArtifactData="NonShipping=false"
                            PublishFlatContainer="true"
                            RelativeBlobPath="WindowsDesktop/$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)/%(Filename)%(Extension)" />
-    </ItemsToPushToBlobFeed>
   </ItemGroup>
 
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,20 +2,24 @@
 
   <PropertyGroup>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+    <PublishDependsOnTargets Condition="'$(DotNetBuildRepo)' == 'true'">$(PublishDependsOnTargets);PublishWindowsDesktopInstallers</PublishDependsOnTargets>
   </PropertyGroup>
 
   <!-- Include installer archives and packages which aren't globbed by default. -->
-  <ItemGroup Condition="'$(DotNetBuildRepo)' == 'true'">
-    <!--
-       MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion is x64 version - there is no Rid-specific property.
-       TODO: This will need to be updated to support arm64.
-    -->
-    <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)**\*.zip;
-                                    $(ArtifactsPackagesDir)**\*.exe;
-                                    $(ArtifactsPackagesDir)**\*.msi"
-                           ManifestArtifactData="NonShipping=false"
-                           PublishFlatContainer="true"
-                           RelativeBlobPath="WindowsDesktop/$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)/%(Filename)%(Extension)" />
-  </ItemGroup>
+  <Target Name="PublishWindowsDesktopInstallers">
+    <MSBuild Projects="$(RepoRoot)src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj"
+             Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" ItemName="WindowsDesktopRuntimePackProductVersion" />
+    </MSBuild>
+
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)**\*.zip;
+                                      $(ArtifactsPackagesDir)**\*.exe;
+                                      $(ArtifactsPackagesDir)**\*.msi"
+                             ManifestArtifactData="NonShipping=false"
+                             PublishFlatContainer="true"
+                             RelativeBlobPath="WindowsDesktop/$(WindowsDesktopRuntimePackProductVersion)/%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -7,9 +7,11 @@
 
   <!-- Include installer archives and packages which aren't globbed by default. -->
   <Target Name="PublishWindowsDesktopInstallers">
-    <!-- Retrieve windows desktop runtime pack product version. -->
+    <!-- Retrieve windows desktop runtime pack product version.
+         Don't stabilize the package version in order to retrieve the VersionSuffix. -->
     <MSBuild Projects="$(RepoRoot)src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj"
-             Targets="ReturnProductVersion">
+             Targets="ReturnProductVersion"
+             Properties="IsShipping=false">
       <Output TaskParameter="TargetOutputs" ItemName="WindowsDesktopRuntimePackProductVersion" />
     </MSBuild>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -6,15 +6,13 @@
 
   <!-- Include installer archives and packages which aren't globbed by default. -->
   <ItemGroup Condition="'$(DotNetBuildRepo)' == 'true'">
-    <InstallerToPublish Include="$(ArtifactsPackagesDir)**\*.zip;
-                                 $(ArtifactsPackagesDir)**\*.exe;
-                                 $(ArtifactsPackagesDir)**\*.msi" />
-
     <!--
        MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion is x64 version - there is no Rid-specific property.
        TODO: This will need to be updated to support arm64.
     -->
-    <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)"
+    <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)**\*.zip;
+                                   $(ArtifactsPackagesDir)**\*.exe;
+                                   $(ArtifactsPackagesDir)**\*.msi"
                            ManifestArtifactData="NonShipping=false"
                            PublishFlatContainer="true"
                            RelativeBlobPath="WindowsDesktop/$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)/%(Filename)%(Extension)" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -6,7 +6,7 @@
 
   <!-- Include installer archives and packages which aren't globbed by default. -->
   <Target Name="PublishWindowsDesktopInstallers"
-          BeforeTargets="BeforePublish;PublishToAzureDevOpsArtifacts"
+          BeforeTargets="BeforePublish"
           Condition="'$(DotNetBuildRepo)' == 'true'">
     <!-- Retrieve windows desktop runtime pack product version.
          Don't stabilize the package version in order to retrieve the VersionSuffix. -->
@@ -22,6 +22,7 @@
                                    $(ArtifactsPackagesDir)**\*.msi" />
       <ItemsToPushToBlobFeed Include="@(InstallerToPublish)"
                              IsShipping="true"
+                             ManifestArtifactData="DotNetReleaseShipping=true"
                              PublishFlatContainer="true"
                              RelativeBlobPath="WindowsDesktop/$(WindowsDesktopRuntimePackProductVersion)/%(Filename)%(Extension)" />
     </ItemGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,36 +2,23 @@
 
   <PropertyGroup>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers</PublishDependsOnTargets>
   </PropertyGroup>
 
-  <ItemGroup>
-    <_InstallersToPublish Remove="@(_InstallersToPublish)" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.zip" UploadPathSegment="WindowsDesktop" Condition="'$(DotNetBuildRepo)' == 'true'" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.exe" UploadPathSegment="WindowsDesktop" Condition="'$(DotNetBuildRepo)' == 'true'" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.msi" UploadPathSegment="WindowsDesktop" Condition="'$(DotNetBuildRepo)' == 'true'" />
+  <!-- Include installer archives and packages which aren't globbed by default. -->
+  <ItemGroup Condition="'$(DotNetBuildRepo)' == 'true'">
+    <InstallerToPublish Include="$(ArtifactsPackagesDir)**\*.zip;
+                                 $(ArtifactsPackagesDir)**\*.exe;
+                                 $(ArtifactsPackagesDir)**\*.msi" />
+
+    <!--
+       MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion is x64 version - there is no Rid-specific property.
+       TODO: This will need to be updated to support arm64.
+    -->
+    <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)"
+                           ManifestArtifactData="NonShipping=false"
+                           PublishFlatContainer="true"
+                           RelativeBlobPath="WindowsDesktop/$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)/%(Filename)%(Extension)" />
+    </ItemsToPushToBlobFeed>
   </ItemGroup>
-
-  <Target Name="_PublishInstallers">
-
-    <ItemGroup>
-      <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows.
-           Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
-           the nupkgs pushed. Do not do this if building from source, since we want the source build intermediate package
-           to be published. Use DotNetBuildRepo as DotNetBuildFromSource is only set in the internal source build,
-           and Build.proj is invoked from the wrapper build. -->
-      <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true' and '$(DotNetBuildRepo)' != 'true'" />
-
-      <!--
-         MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion is x64 version - there is no Rid-specific property.
-         TODO: This will need to be updated to support arm64.
-      -->
-      <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
-        <ManifestArtifactData>NonShipping=false</ManifestArtifactData>
-        <PublishFlatContainer>true</PublishFlatContainer>
-        <RelativeBlobPath>%(_InstallersToPublish.UploadPathSegment)/$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)/%(Filename)%(Extension)</RelativeBlobPath>
-      </ItemsToPushToBlobFeed>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -13,14 +13,15 @@
     <MSBuild Projects="$(RepoRoot)src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj"
              Targets="ReturnProductVersion"
              Properties="IsShipping=false">
-      <Output TaskParameter="TargetOutputs" ItemName="WindowsDesktopRuntimePackProductVersion" />
+      <Output TaskParameter="TargetOutputs" PropertyName="WindowsDesktopRuntimePackProductVersion" />
     </MSBuild>
 
     <ItemGroup>
-      <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)**\*.zip;
-                                      $(ArtifactsPackagesDir)**\*.exe;
-                                      $(ArtifactsPackagesDir)**\*.msi"
-                             ManifestArtifactData="NonShipping=false"
+      <InstallerToPublish Include="$(ArtifactsPackagesDir)**\*.zip;
+                                   $(ArtifactsPackagesDir)**\*.exe;
+                                   $(ArtifactsPackagesDir)**\*.msi" />
+      <ItemsToPushToBlobFeed Include="@(InstallerToPublish)"
+                             IsShipping="true"
                              PublishFlatContainer="true"
                              RelativeBlobPath="WindowsDesktop/$(WindowsDesktopRuntimePackProductVersion)/%(Filename)%(Extension)" />
     </ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4101

Enables publishing in VMR.

Installers are not collected by common arcade publishing infra. All repos that build installers need to collect them in Publishing.props file.

Additionally installers need to be published to correct blob path, which includes versioned sub-directory. I'm obtaining the version value from `MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion` property which is defined in all architecture builds. This repo does not appear to define any RID-specific properties, i.e. `TargetRid`.