### PR TITLE
Convert to 1ES Pipeline Template

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -37,14 +37,8 @@ variables:
     value: .NETCoreValidation
 
   # Produce test-signed build for PR and Public builds
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: test
-
-  # Set up non-PR build from internal project
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: $[ coalesce(variables.OfficialSignType, 'real') ]
+  - name: SignType
+    value: test
 
 stages:
 - stage: Build
@@ -67,49 +61,3 @@ stages:
     parameters:
       name: win_arm64
       targetArchitecture: arm64
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - stage: PrepareForPublish
-    displayName: Prepare for Publish
-    dependsOn: Build
-    jobs:
-    # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
-    - template: /eng/pipelines/jobs/prepare-signed-artifacts-PR.yml
-      parameters:
-        PublishRidAgnosticPackagesFromJobName: win_x64
-    # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        publishAssetsImmediately: true
-        dependsOn: PrepareSignedArtifacts
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
-
-  # Stages-based publishing entry point
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      validateDependsOn:
-      - PrepareForPublish
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      publishAssetsImmediately: true
-
-      SDLValidationParameters:
-        enable: false
-        params: >-
-          -SourceToolsList @("policheck","credscan")
-          -TsaInstanceURL https://devdiv.visualstudio.com/
-          -TsaProjectName DEVDIV
-          -TsaNotificationEmail wffteam@microsoft.com
-          -TsaCodebaseAdmin REDMOND\advolker
-          -TsaBugAreaPath "DevDiv\NET Fundamentals\WindowsDesktop"
-          -TsaIterationPath DevDiv
-          -TsaRepositoryName WindowsDesktop
-          -TsaCodebaseName WindowsDesktop
-          -TsaOnboard $True
-          -TsaPublish $True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ extends:
         - template: /eng/pipelines/jobs/prepare-signed-artifacts.yml@self
           parameters:
             PublishRidAgnosticPackagesFromJobName: win_x64
-        - template: /eng/common/templates/job/publish-build-assets.yml@self
+        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:
             publishUsingPipelines: true
             publishAssetsImmediately: true
@@ -84,7 +84,7 @@ extends:
             pool:
               name: NetCore1ESPool-Internal
               demands: ImageOverride -equals windows.vs2022preview.amd64
-      - template: /eng/common/templates/post-build/post-build.yml@self
+      - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
           publishingInfraVersion: 3
           validateDependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    featureFlags:
+      autoBaseline: true
     pool:
       name: NetCore1ESPool-Internal
       image: 1es-windows-2022-pt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# This pipeline will be extended to the OneESPT template
+# If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
 trigger:
   batch: true
   branches:
@@ -6,110 +10,91 @@ trigger:
     - release/*
     - internal/release/*
     - experimental/*
-
 pr:
 - main
 - release/*
 - experimental/*
-
 name: $(Date:yyyyMMdd)$(Rev:.r)
-
 variables:
-  - name: TeamName
-    value: dotnet-core-acquisition
-  # Skip Running CI tests
-  - name: SkipTests
+- name: TeamName
+  value: dotnet-core-acquisition
+- name: SkipTests
+  value: false
+- name: OfficialBuildId
+  value: $(Build.BuildNumber)
+- ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+  - name: PostBuildSign
     value: false
-  # Set Official Build Id
-  - name: OfficialBuildId
-    value: $(Build.BuildNumber)
-  - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
-    - name: PostBuildSign
-      value: false
-  - ${{ else }}:
-    - name: PostBuildSign
-      value: true
-
-  # Set the target blob feed for package publish during official and validation builds.
-  - name: _DotNetArtifactsCategory
-    value: .NETCore
-  - name: _DotNetValidationArtifactsCategory
-    value: .NETCoreValidation
-
-  # Produce test-signed build for PR and Public builds
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: test
-
-  # Set up non-PR build from internal project
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: $[ coalesce(variables.OfficialSignType, 'real') ]
-
-stages:
-- stage: Build
-  jobs:
-
-  # Windows x64
-  - template: /eng/pipelines/jobs/windows-build.yml
-    parameters:
-      name: win_x64
-      targetArchitecture: x64
-
-  # Windows x86
-  - template: /eng/pipelines/jobs/windows-build.yml
-    parameters:
-      name: win_x86
-      targetArchitecture: x86
-
-  # Windows arm64
-  - template: /eng/pipelines/jobs/windows-build.yml
-    parameters:
-      name: win_arm64
-      targetArchitecture: arm64
-
+- ${{ else }}:
+  - name: PostBuildSign
+    value: true
+- name: _DotNetArtifactsCategory
+  value: .NETCore
+- name: _DotNetValidationArtifactsCategory
+  value: .NETCoreValidation
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: SignType
+    value: test
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - stage: PrepareForPublish
-    displayName: Prepare for Publish
-    dependsOn: Build
-    jobs:
-    # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
-    - template: /eng/pipelines/jobs/prepare-signed-artifacts.yml
-      parameters:
-        PublishRidAgnosticPackagesFromJobName: win_x64
-    # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        publishAssetsImmediately: true
-        dependsOn: PrepareSignedArtifacts
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
-
-  # Stages-based publishing entry point
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      validateDependsOn:
-      - PrepareForPublish
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      publishAssetsImmediately: true
-
-      SDLValidationParameters:
-        enable: false
-        params: >-
-          -SourceToolsList @("policheck","credscan")
-          -TsaInstanceURL https://devdiv.visualstudio.com/
-          -TsaProjectName DEVDIV
-          -TsaNotificationEmail wffteam@microsoft.com
-          -TsaCodebaseAdmin REDMOND\advolker
-          -TsaBugAreaPath "DevDiv\NET Fundamentals\WindowsDesktop"
-          -TsaIterationPath DevDiv
-          -TsaRepositoryName WindowsDesktop
-          -TsaCodebaseName WindowsDesktop
-          -TsaOnboard $True
-          -TsaPublish $True
+  - name: SignType
+    value: $[ coalesce(variables.OfficialSignType, 'real') ]
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: Build
+      jobs:
+      - template: /eng/pipelines/jobs/windows-build.yml@self
+        parameters:
+          name: win_x64
+          targetArchitecture: x64
+      - template: /eng/pipelines/jobs/windows-build.yml@self
+        parameters:
+          name: win_x86
+          targetArchitecture: x86
+      - template: /eng/pipelines/jobs/windows-build.yml@self
+        parameters:
+          name: win_arm64
+          targetArchitecture: arm64
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - stage: PrepareForPublish
+        displayName: Prepare for Publish
+        dependsOn: Build
+        jobs:
+        - template: /eng/pipelines/jobs/prepare-signed-artifacts.yml@self
+          parameters:
+            PublishRidAgnosticPackagesFromJobName: win_x64
+        - template: /eng/common/templates/job/publish-build-assets.yml@self
+          parameters:
+            publishUsingPipelines: true
+            publishAssetsImmediately: true
+            dependsOn: PrepareSignedArtifacts
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals windows.vs2022preview.amd64
+      - template: /eng/common/templates/post-build/post-build.yml@self
+        parameters:
+          publishingInfraVersion: 3
+          validateDependsOn:
+          - PrepareForPublish
+          enableSymbolValidation: false
+          enableSigningValidation: false
+          enableNugetValidation: false
+          enableSourceLinkValidation: false
+          publishAssetsImmediately: true
+          SDLValidationParameters:
+            enable: false
+            params: >-
+              -SourceToolsList @("policheck","credscan") -TsaInstanceURL https://devdiv.visualstudio.com/ -TsaProjectName DEVDIV -TsaNotificationEmail wffteam@microsoft.com -TsaCodebaseAdmin REDMOND\advolker -TsaBugAreaPath "DevDiv\NET Fundamentals\WindowsDesktop" -TsaIterationPath DevDiv -TsaRepositoryName WindowsDesktop -TsaCodebaseName WindowsDesktop -TsaOnboard $True -TsaPublish $True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,16 +10,21 @@ trigger:
     - release/*
     - internal/release/*
     - experimental/*
+
 pr:
 - main
 - release/*
 - experimental/*
+
 name: $(Date:yyyyMMdd)$(Rev:.r)
+
 variables:
 - name: TeamName
   value: dotnet-core-acquisition
+  # Skip Running CI tests
 - name: SkipTests
   value: false
+  # Set Official Build Id
 - name: OfficialBuildId
   value: $(Build.BuildNumber)
 - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
@@ -28,16 +33,23 @@ variables:
 - ${{ else }}:
   - name: PostBuildSign
     value: true
+
+  # Set the target blob feed for package publish during official and validation builds.
 - name: _DotNetArtifactsCategory
   value: .NETCore
 - name: _DotNetValidationArtifactsCategory
   value: .NETCoreValidation
+
+  # Produce test-signed build for PR and Public builds
 - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
   - name: SignType
     value: test
+
+  # Set up non-PR build from internal project
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - name: SignType
     value: $[ coalesce(variables.OfficialSignType, 'real') ]
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -58,26 +70,35 @@ extends:
     stages:
     - stage: Build
       jobs:
+
+      # Windows x64
       - template: /eng/pipelines/jobs/windows-build.yml@self
         parameters:
           name: win_x64
           targetArchitecture: x64
+
+      # Windows x86
       - template: /eng/pipelines/jobs/windows-build.yml@self
         parameters:
           name: win_x86
           targetArchitecture: x86
+
+      # Windows arm64
       - template: /eng/pipelines/jobs/windows-build.yml@self
         parameters:
           name: win_arm64
           targetArchitecture: arm64
+
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - stage: PrepareForPublish
         displayName: Prepare for Publish
         dependsOn: Build
         jobs:
+        # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
         - template: /eng/pipelines/jobs/prepare-signed-artifacts.yml@self
           parameters:
             PublishRidAgnosticPackagesFromJobName: win_x64
+        # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:
             publishUsingPipelines: true
@@ -86,6 +107,8 @@ extends:
             pool:
               name: NetCore1ESPool-Internal
               demands: ImageOverride -equals windows.vs2022preview.amd64
+
+      # Stages-based publishing entry point
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
           publishingInfraVersion: 3
@@ -96,7 +119,18 @@ extends:
           enableNugetValidation: false
           enableSourceLinkValidation: false
           publishAssetsImmediately: true
+
           SDLValidationParameters:
             enable: false
             params: >-
-              -SourceToolsList @("policheck","credscan") -TsaInstanceURL https://devdiv.visualstudio.com/ -TsaProjectName DEVDIV -TsaNotificationEmail wffteam@microsoft.com -TsaCodebaseAdmin REDMOND\advolker -TsaBugAreaPath "DevDiv\NET Fundamentals\WindowsDesktop" -TsaIterationPath DevDiv -TsaRepositoryName WindowsDesktop -TsaCodebaseName WindowsDesktop -TsaOnboard $True -TsaPublish $True
+              -SourceToolsList @("policheck","credscan")
+              -TsaInstanceURL https://devdiv.visualstudio.com/
+              -TsaProjectName DEVDIV
+              -TsaNotificationEmail wffteam@microsoft.com
+              -TsaCodebaseAdmin REDMOND\advolker
+              -TsaBugAreaPath "DevDiv\NET Fundamentals\WindowsDesktop"
+              -TsaIterationPath DevDiv
+              -TsaRepositoryName WindowsDesktop
+              -TsaCodebaseName WindowsDesktop
+              -TsaOnboard $True
+              -TsaPublish $True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,3 @@
-# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
-# This pipeline will be extended to the OneESPT template
-# If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
 trigger:
   batch: true
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,8 +48,8 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-2022
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022-pt
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,11 +7,6 @@ trigger:
     - internal/release/*
     - experimental/*
 
-pr:
-- main
-- release/*
-- experimental/*
-
 name: $(Date:yyyyMMdd)$(Rev:.r)
 
 variables:
@@ -37,14 +32,8 @@ variables:
   value: .NETCoreValidation
 
   # Produce test-signed build for PR and Public builds
-- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-  - name: SignType
-    value: test
-
-  # Set up non-PR build from internal project
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - name: SignType
-    value: $[ coalesce(variables.OfficialSignType, 'real') ]
+- name: SignType
+  value: $[ coalesce(variables.OfficialSignType, 'real') ]
 
 resources:
   repositories:
@@ -85,48 +74,47 @@ extends:
           name: win_arm64
           targetArchitecture: arm64
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - stage: PrepareForPublish
-        displayName: Prepare for Publish
-        dependsOn: Build
-        jobs:
-        # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
-        - template: /eng/pipelines/jobs/prepare-signed-artifacts.yml@self
-          parameters:
-            PublishRidAgnosticPackagesFromJobName: win_x64
-        # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-          parameters:
-            publishUsingPipelines: true
-            publishAssetsImmediately: true
-            dependsOn: PrepareSignedArtifacts
-            pool:
-              name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2022preview.amd64
-
-      # Stages-based publishing entry point
-      - template: /eng/common/templates-official/post-build/post-build.yml@self
+    - stage: PrepareForPublish
+      displayName: Prepare for Publish
+      dependsOn: Build
+      jobs:
+      # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
+      - template: /eng/pipelines/jobs/prepare-signed-artifacts.yml@self
         parameters:
-          publishingInfraVersion: 3
-          validateDependsOn:
-          - PrepareForPublish
-          enableSymbolValidation: false
-          enableSigningValidation: false
-          enableNugetValidation: false
-          enableSourceLinkValidation: false
+          PublishRidAgnosticPackagesFromJobName: win_x64
+      # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          publishUsingPipelines: true
           publishAssetsImmediately: true
+          dependsOn: PrepareSignedArtifacts
+          pool:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals windows.vs2022preview.amd64
 
-          SDLValidationParameters:
-            enable: false
-            params: >-
-              -SourceToolsList @("policheck","credscan")
-              -TsaInstanceURL https://devdiv.visualstudio.com/
-              -TsaProjectName DEVDIV
-              -TsaNotificationEmail wffteam@microsoft.com
-              -TsaCodebaseAdmin REDMOND\advolker
-              -TsaBugAreaPath "DevDiv\NET Fundamentals\WindowsDesktop"
-              -TsaIterationPath DevDiv
-              -TsaRepositoryName WindowsDesktop
-              -TsaCodebaseName WindowsDesktop
-              -TsaOnboard $True
-              -TsaPublish $True
+    # Stages-based publishing entry point
+    - template: /eng/common/templates-official/post-build/post-build.yml@self
+      parameters:
+        publishingInfraVersion: 3
+        validateDependsOn:
+        - PrepareForPublish
+        enableSymbolValidation: false
+        enableSigningValidation: false
+        enableNugetValidation: false
+        enableSourceLinkValidation: false
+        publishAssetsImmediately: true
+
+        SDLValidationParameters:
+          enable: false
+          params: >-
+            -SourceToolsList @("policheck","credscan")
+            -TsaInstanceURL https://devdiv.visualstudio.com/
+            -TsaProjectName DEVDIV
+            -TsaNotificationEmail wffteam@microsoft.com
+            -TsaCodebaseAdmin REDMOND\advolker
+            -TsaBugAreaPath "DevDiv\NET Fundamentals\WindowsDesktop"
+            -TsaIterationPath DevDiv
+            -TsaRepositoryName WindowsDesktop
+            -TsaCodebaseName WindowsDesktop
+            -TsaOnboard $True
+            -TsaPublish $True

--- a/eng/pipelines/jobs/prepare-signed-artifacts-PR.yml
+++ b/eng/pipelines/jobs/prepare-signed-artifacts-PR.yml
@@ -15,19 +15,6 @@ jobs:
     clean: all
 
   steps:
-
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: NuGetAuthenticate@1
-
-    - task: MicroBuildSigningPlugin@2
-      displayName: Install MicroBuild plugin for Signing
-      inputs:
-        signType: $(SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      condition: and(succeeded(),
-                     in(variables['SignType'], 'real', 'test'))
-
   - task: DownloadBuildArtifacts@0
     displayName: Download IntermediateUnsignedArtifacts
     inputs:

--- a/eng/pipelines/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/jobs/prepare-signed-artifacts.yml
@@ -19,17 +19,14 @@ jobs:
       targetPath: '$(Build.StagingDirectory)\BuildLogs'
       artifactName: Logs-PrepareSignedArtifacts
   steps:
-
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: NuGetAuthenticate@1
-
-    - task: MicroBuildSigningPlugin@2
-      displayName: Install MicroBuild plugin for Signing
-      inputs:
-        signType: $(SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
+  - task: NuGetAuthenticate@1
+  - task: MicroBuildSigningPlugin@2
+    displayName: Install MicroBuild plugin for Signing
+    inputs:
+      signType: $(SignType)
+      zipSources: false
+      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+    condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
   - task: DownloadBuildArtifacts@0
     displayName: Download IntermediateUnsignedArtifacts
     inputs:

--- a/eng/pipelines/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/jobs/prepare-signed-artifacts.yml
@@ -1,49 +1,41 @@
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Artifact BuildLogs' in the templateContext section.
 parameters:
   dependsOn: []
   PublishRidAgnosticPackagesFromJobName: ''
-
 jobs:
 - job: PrepareSignedArtifacts
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
-  pool:
-    name: NetCore1ESPool-Svc-Internal
-    demands: ImageOverride -equals windows.vs2019.amd64
-  # Double the default timeout.
   timeoutInMinutes: 120
   workspace:
     clean: all
-
+  templateContext:
+    outputs:
+    - output: pipelineArtifact
+      displayName: 'Publish Artifact BuildLogs'
+      condition: succeededOrFailed()
+      targetPath: '$(Build.StagingDirectory)\BuildLogs'
+      artifactName: Logs-PrepareSignedArtifacts
   steps:
-
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: NuGetAuthenticate@1
-
     - task: MicroBuildSigningPlugin@2
       displayName: Install MicroBuild plugin for Signing
       inputs:
         signType: $(SignType)
         zipSources: false
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      condition: and(succeeded(),
-                     in(variables['SignType'], 'real', 'test'))
-
+      condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
   - task: DownloadBuildArtifacts@0
     displayName: Download IntermediateUnsignedArtifacts
     inputs:
       artifactName: IntermediateUnsignedArtifacts
       downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
-
   - script: >
-      build.cmd -ci
-      -projects $(Build.SourcesDirectory)\src\publish\prepare-artifacts.proj
-      -c Release
-      /p:PublishRidAgnosticPackagesFromJobName=${{ parameters.PublishRidAgnosticPackagesFromJobName }}
-      /p:SignType=$(SignType)
-      /p:DotNetSignType=$(SignType)
-      /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+      build.cmd -ci -projects $(Build.SourcesDirectory)\src\publish\prepare-artifacts.proj -c Release /p:PublishRidAgnosticPackagesFromJobName=${{ parameters.PublishRidAgnosticPackagesFromJobName }} /p:SignType=$(SignType) /p:DotNetSignType=$(SignType) /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
     displayName: Prepare artifacts and upload to build
-
   - task: CopyFiles@2
     displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
     inputs:
@@ -53,11 +45,4 @@ jobs:
         **/*.binlog
       TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
     continueOnError: true
-    condition: succeededOrFailed()
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifact BuildLogs
-    inputs:
-      PathtoPublish: '$(Build.StagingDirectory)\BuildLogs'
-      ArtifactName: Logs-PrepareSignedArtifacts
     condition: succeededOrFailed()

--- a/eng/pipelines/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/jobs/prepare-signed-artifacts.yml
@@ -1,6 +1,3 @@
-# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
-# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Artifact BuildLogs' in the templateContext section.
 parameters:
   dependsOn: []
   PublishRidAgnosticPackagesFromJobName: ''

--- a/eng/pipelines/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/jobs/prepare-signed-artifacts.yml
@@ -4,13 +4,16 @@
 parameters:
   dependsOn: []
   PublishRidAgnosticPackagesFromJobName: ''
+
 jobs:
 - job: PrepareSignedArtifacts
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
+  # Double the default timeout.
   timeoutInMinutes: 120
   workspace:
     clean: all
+
   templateContext:
     outputs:
     - output: pipelineArtifact
@@ -19,8 +22,10 @@ jobs:
       targetPath: '$(Build.StagingDirectory)\BuildLogs'
       artifactName: Logs-PrepareSignedArtifacts
   steps:
+
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: NuGetAuthenticate@1
+
     - task: MicroBuildSigningPlugin@2
       displayName: Install MicroBuild plugin for Signing
       inputs:
@@ -33,9 +38,17 @@ jobs:
     inputs:
       artifactName: IntermediateUnsignedArtifacts
       downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
+
   - script: >
-      build.cmd -ci -projects $(Build.SourcesDirectory)\src\publish\prepare-artifacts.proj -c Release /p:PublishRidAgnosticPackagesFromJobName=${{ parameters.PublishRidAgnosticPackagesFromJobName }} /p:SignType=$(SignType) /p:DotNetSignType=$(SignType) /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+      build.cmd -ci
+      -projects $(Build.SourcesDirectory)\src\publish\prepare-artifacts.proj
+      -c Release
+      /p:PublishRidAgnosticPackagesFromJobName=${{ parameters.PublishRidAgnosticPackagesFromJobName }}
+      /p:SignType=$(SignType)
+      /p:DotNetSignType=$(SignType)
+      /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
     displayName: Prepare artifacts and upload to build
+
   - task: CopyFiles@2
     displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
     inputs:

--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -11,11 +11,7 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     pool:
       # Use a hosted pool when possible.
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        vmImage: 'windows-2019'
-      ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals windows.vs2019.amd64
+      vmImage: 'windows-2019'
     strategy:
       matrix: 
         Debug:
@@ -35,37 +31,10 @@ jobs:
         value: /p:DotNetSignType=$(SignType)
       - name: TargetArchitecture
         value: ${{ parameters.targetArchitecture }}
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - name: _InternalRuntimeDownloadArgs
-          value: ''
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - group: DotNet-MSRC-Storage
-        - name: _InternalRuntimeDownloadArgs
-          value: >-
-            /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
-            /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+      - name: _InternalRuntimeDownloadArgs
+        value: ''
 
     steps:
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: NuGetAuthenticate@1
-
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), 
-                       in(variables['SignType'], 'real', 'test'))
     # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
     # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
     - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
@@ -77,12 +46,6 @@ jobs:
         $(MsbuildSigningArguments)
         $(_InternalRuntimeDownloadArgs)
       displayName: Build
-
-    # Generate SBOM for the internal leg only
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: ..\..\common\templates\steps\generate-sbom.yml
-        parameters:
-          name: Generate_SBOM_${{ parameters.name }}
 
     - template: /eng/pipelines/steps/upload-job-artifacts-PR.yml
       parameters:

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -28,50 +28,44 @@ jobs:
     value: /p:DotNetSignType=$(SignType)
   - name: TargetArchitecture
     value: ${{ parameters.targetArchitecture }}
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    - name: _InternalRuntimeDownloadArgs
-      value: ''
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - group: DotNet-MSRC-Storage
-    - name: _InternalRuntimeDownloadArgs
-      value: >-
-        /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
-        /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+  - group: DotNet-MSRC-Storage
+  - name: _InternalRuntimeDownloadArgs
+    value: >-
+      /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
+      /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
   templateContext:
     outputs:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - output: buildArtifacts
-        displayName: 'Publish Artifacts'
-        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-        PathtoPublish: '$(Build.StagingDirectory)/Artifacts'
-        ArtifactName: IntermediateUnsignedArtifacts
-        ArtifactType: container
+    - output: buildArtifacts
+      displayName: 'Publish Artifacts'
+      condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+      PathtoPublish: '$(Build.StagingDirectory)/Artifacts'
+      ArtifactName: IntermediateUnsignedArtifacts
+      ArtifactType: container
     - output: pipelineArtifact
       displayName: 'Publish BuildLogs'
       condition: succeededOrFailed()
       targetPath: '$(Build.StagingDirectory)/BuildLogs'
       artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
   steps:
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - task: NuGetAuthenticate@1
+  - task: NuGetAuthenticate@1
 
-    - task: PowerShell@2
-      displayName: Setup Private Feeds Credentials
-      inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-      env:
-        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+  - task: PowerShell@2
+    displayName: Setup Private Feeds Credentials
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+    env:
+      Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-    - task: MicroBuildSigningPlugin@2
-      displayName: Install MicroBuild plugin for Signing
-      inputs:
-        signType: $(SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      continueOnError: false
-      condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
+  - task: MicroBuildSigningPlugin@2
+    displayName: Install MicroBuild plugin for Signing
+    inputs:
+      signType: $(SignType)
+      zipSources: false
+      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+    continueOnError: false
+    condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
     # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
     # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
   - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
@@ -84,11 +78,10 @@ jobs:
       $(_InternalRuntimeDownloadArgs)
     displayName: Build
 
-    # Generate SBOM for the internal leg only
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates-official/steps/generate-sbom.yml@self
-      parameters:
-        name: Generate_SBOM_${{ parameters.name }}
+    # Generate SBOM
+  - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+    parameters:
+      name: Generate_SBOM_${{ parameters.name }}
 
   - template: /eng/pipelines/steps/upload-job-artifacts.yml@self
     parameters:

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -9,6 +9,7 @@ parameters:
   skipTests: $(SkipTests)
   targetArchitecture: null
   timeoutInMinutes: 120
+
 jobs:
 - job: ${{ parameters.name }}
   displayName: ${{ parameters.displayName }}
@@ -24,7 +25,10 @@ jobs:
   variables:
   - name: CommonMSBuildArgs
     value: >-
-      -c $(_BuildConfig) /p:OfficialBuildId=$(OfficialBuildId) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:SkipTests=${{ parameters.skipTests }}
+      -c $(_BuildConfig)
+      /p:OfficialBuildId=$(OfficialBuildId)
+      /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+      /p:SkipTests=${{ parameters.skipTests }}
   - name: MsbuildSigningArguments
     value: /p:DotNetSignType=$(SignType)
   - name: TargetArchitecture
@@ -36,7 +40,9 @@ jobs:
     - group: DotNet-MSRC-Storage
     - name: _InternalRuntimeDownloadArgs
       value: >-
-        /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+        /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
+        /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+
   templateContext:
     outputs:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -54,6 +60,7 @@ jobs:
   steps:
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - task: NuGetAuthenticate@1
+
     - task: PowerShell@2
       displayName: Setup Private Feeds Credentials
       inputs:
@@ -61,6 +68,7 @@ jobs:
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
       env:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
     - task: MicroBuildSigningPlugin@2
       displayName: Install MicroBuild plugin for Signing
       inputs:
@@ -69,15 +77,24 @@ jobs:
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
       continueOnError: false
       condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
+    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
+    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
   - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
     displayName: Clear NuGet http cache (if exists)
+
   - script: >-
-      build.cmd -ci -test $(CommonMSBuildArgs) $(MsbuildSigningArguments) $(_InternalRuntimeDownloadArgs)
+      build.cmd -ci -test
+      $(CommonMSBuildArgs)
+      $(MsbuildSigningArguments)
+      $(_InternalRuntimeDownloadArgs)
     displayName: Build
+
+    # Generate SBOM for the internal leg only
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
       parameters:
         name: Generate_SBOM_${{ parameters.name }}
+
   - template: /eng/pipelines/steps/upload-job-artifacts.yml@self
     parameters:
       name: ${{ parameters.name }}

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -40,12 +40,12 @@ jobs:
   templateContext:
     outputs:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - output: pipelineArtifact
+      - output: buildArtifacts
         displayName: 'Publish Artifacts'
         condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-        targetPath: '$(Build.StagingDirectory)/Artifacts'
-        artifactName: IntermediateUnsignedArtifacts
-        artifactType: container
+        PathtoPublish: '$(Build.StagingDirectory)/Artifacts'
+        ArtifactName: IntermediateUnsignedArtifacts
+        ArtifactType: container
     - output: pipelineArtifact
       displayName: 'Publish BuildLogs'
       condition: succeededOrFailed()

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -75,7 +75,7 @@ jobs:
       build.cmd -ci -test $(CommonMSBuildArgs) $(MsbuildSigningArguments) $(_InternalRuntimeDownloadArgs)
     displayName: Build
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/steps/generate-sbom.yml@self
+    - template: /eng/common/templates-official/steps/generate-sbom.yml@self
       parameters:
         name: Generate_SBOM_${{ parameters.name }}
   - template: /eng/pipelines/steps/upload-job-artifacts.yml@self

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -1,8 +1,3 @@
-# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
-# Outputs were added with YAML Conditional expressions generated using AI in a best attempt to preserve the boolean logic that would have lead to the tasks producing outputs executing before conversion. You may need to review the generated expressions for correctness of the execution logic, and you will need to manually translate any cross-template parameters.
-# Output from "eng\pipelines\steps\upload-job-artifacts.yml" added to job "${{ parameters.displayName }}" with conditionals extracted using AI from the following files: "eng\pipelines\steps\upload-job-artifacts.yml".
-
 parameters:
   additionalMSBuildArguments: ''
   displayName: ''

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -1,89 +1,83 @@
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# Outputs were added with YAML Conditional expressions generated using AI in a best attempt to preserve the boolean logic that would have lead to the tasks producing outputs executing before conversion. You may need to review the generated expressions for correctness of the execution logic, and you will need to manually translate any cross-template parameters.
+# Output from "eng\pipelines\steps\upload-job-artifacts.yml" added to job "${{ parameters.displayName }}" with conditionals extracted using AI from the following files: "eng\pipelines\steps\upload-job-artifacts.yml".
+
 parameters:
   additionalMSBuildArguments: ''
   displayName: ''
   skipTests: $(SkipTests)
   targetArchitecture: null
   timeoutInMinutes: 120
-
 jobs:
-  - job: ${{ parameters.name }}
-    displayName: ${{ parameters.displayName }}
-    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
-    pool:
-      # Use a hosted pool when possible.
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        vmImage: 'windows-2019'
-      ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals windows.vs2019.amd64
-    strategy:
-      matrix: 
-        Debug:
-          _BuildConfig: Debug
-        Release:
-          _BuildConfig: Release
-    workspace:
-      clean: all
-    variables: 
-      - name: CommonMSBuildArgs
-        value: >-
-          -c $(_BuildConfig)
-          /p:OfficialBuildId=$(OfficialBuildId)
-          /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-          /p:SkipTests=${{ parameters.skipTests }}
-      - name: MsbuildSigningArguments
-        value: /p:DotNetSignType=$(SignType)
-      - name: TargetArchitecture
-        value: ${{ parameters.targetArchitecture }}
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - name: _InternalRuntimeDownloadArgs
-          value: ''
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - group: DotNet-MSRC-Storage
-        - name: _InternalRuntimeDownloadArgs
-          value: >-
-            /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
-            /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
-
-    steps:
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: NuGetAuthenticate@1
-
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), 
-                       in(variables['SignType'], 'real', 'test'))
-    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
-    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
-    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
-      displayName: Clear NuGet http cache (if exists)
-
-    - script: >-
-        build.cmd -ci -test
-        $(CommonMSBuildArgs)
-        $(MsbuildSigningArguments)
-        $(_InternalRuntimeDownloadArgs)
-      displayName: Build
-
-    # Generate SBOM for the internal leg only
+- job: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }}
+  timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+  strategy:
+    matrix:
+      Debug:
+        _BuildConfig: Debug
+      Release:
+        _BuildConfig: Release
+  workspace:
+    clean: all
+  variables:
+  - name: CommonMSBuildArgs
+    value: >-
+      -c $(_BuildConfig) /p:OfficialBuildId=$(OfficialBuildId) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:SkipTests=${{ parameters.skipTests }}
+  - name: MsbuildSigningArguments
+    value: /p:DotNetSignType=$(SignType)
+  - name: TargetArchitecture
+    value: ${{ parameters.targetArchitecture }}
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    - name: _InternalRuntimeDownloadArgs
+      value: ''
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - group: DotNet-MSRC-Storage
+    - name: _InternalRuntimeDownloadArgs
+      value: >-
+        /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+  templateContext:
+    outputs:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: ..\..\common\templates\steps\generate-sbom.yml
-        parameters:
-          name: Generate_SBOM_${{ parameters.name }}
-
-    - template: /eng/pipelines/steps/upload-job-artifacts.yml
+      - output: pipelineArtifact
+        displayName: 'Publish Artifacts'
+        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+        targetPath: '$(Build.StagingDirectory)/Artifacts'
+        artifactName: IntermediateUnsignedArtifacts
+        artifactType: container
+    - output: pipelineArtifact
+      displayName: 'Publish BuildLogs'
+      condition: succeededOrFailed()
+      targetPath: '$(Build.StagingDirectory)/BuildLogs'
+      artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
+  steps:
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - task: NuGetAuthenticate@1
+    - task: PowerShell@2
+      displayName: Setup Private Feeds Credentials
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+      env:
+        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild plugin for Signing
+      inputs:
+        signType: $(SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      continueOnError: false
+      condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
+  - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
+    displayName: Clear NuGet http cache (if exists)
+  - script: >-
+      build.cmd -ci -test $(CommonMSBuildArgs) $(MsbuildSigningArguments) $(_InternalRuntimeDownloadArgs)
+    displayName: Build
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/common/templates/steps/generate-sbom.yml@self
       parameters:
-        name: ${{ parameters.name }}
+        name: Generate_SBOM_${{ parameters.name }}
+  - template: /eng/pipelines/steps/upload-job-artifacts.yml@self
+    parameters:
+      name: ${{ parameters.name }}

--- a/eng/pipelines/steps/upload-job-artifacts-PR.yml
+++ b/eng/pipelines/steps/upload-job-artifacts-PR.yml
@@ -2,27 +2,6 @@ parameters:
   name: ''
 
 steps:
-# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - task: CopyFiles@2
-    displayName: Prepare job-specific Artifacts subdirectory
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-      Contents: |
-        Shipping/**/*
-        NonShipping/**/*
-      TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
-      CleanTargetFolder: true
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifacts
-    inputs:
-      pathToPublish: '$(Build.StagingDirectory)/Artifacts'
-      artifactName: IntermediateUnsignedArtifacts
-      artifactType: container
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-
 # Always upload test outputs and build logs.
 - task: PublishTestResults@2
   displayName: Publish Test Results

--- a/eng/pipelines/steps/upload-job-artifacts.yml
+++ b/eng/pipelines/steps/upload-job-artifacts.yml
@@ -1,8 +1,10 @@
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Artifacts' in the templateContext section.
+# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish BuildLogs' in the templateContext section.
 parameters:
   name: ''
-
 steps:
-# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - task: CopyFiles@2
     displayName: Prepare job-specific Artifacts subdirectory
@@ -14,16 +16,6 @@ steps:
       TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
       CleanTargetFolder: true
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifacts
-    inputs:
-      pathToPublish: '$(Build.StagingDirectory)/Artifacts'
-      artifactName: IntermediateUnsignedArtifacts
-      artifactType: container
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-
-# Always upload test outputs and build logs.
 - task: PublishTestResults@2
   displayName: Publish Test Results
   inputs:
@@ -34,7 +26,6 @@ steps:
     testRunTitle: ${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
   condition: always()
-
 - task: CopyFiles@2
   displayName: Prepare BuildLogs staging directory
   inputs:
@@ -44,13 +35,5 @@ steps:
       **/*.binlog
     TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
     CleanTargetFolder: true
-  continueOnError: true
-  condition: succeededOrFailed()
-
-- task: PublishBuildArtifacts@1
-  displayName: Publish BuildLogs
-  inputs:
-    PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
-    ArtifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
   condition: succeededOrFailed()

--- a/eng/pipelines/steps/upload-job-artifacts.yml
+++ b/eng/pipelines/steps/upload-job-artifacts.yml
@@ -1,7 +1,3 @@
-# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
-# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Artifacts' in the templateContext section.
-# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish BuildLogs' in the templateContext section.
 parameters:
   name: ''
 

--- a/eng/pipelines/steps/upload-job-artifacts.yml
+++ b/eng/pipelines/steps/upload-job-artifacts.yml
@@ -2,18 +2,17 @@ parameters:
   name: ''
 
 steps:
-# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - task: CopyFiles@2
-    displayName: Prepare job-specific Artifacts subdirectory
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-      Contents: |
-        Shipping/**/*
-        NonShipping/**/*
-      TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
-      CleanTargetFolder: true
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+# Upload build outputs as build artifacts.
+- task: CopyFiles@2
+  displayName: Prepare job-specific Artifacts subdirectory
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+    Contents: |
+      Shipping/**/*
+      NonShipping/**/*
+    TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
+    CleanTargetFolder: true
+  condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
 
 # Always upload test outputs and build logs.
 - task: PublishTestResults@2

--- a/eng/pipelines/steps/upload-job-artifacts.yml
+++ b/eng/pipelines/steps/upload-job-artifacts.yml
@@ -4,7 +4,9 @@
 # The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish BuildLogs' in the templateContext section.
 parameters:
   name: ''
+
 steps:
+# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - task: CopyFiles@2
     displayName: Prepare job-specific Artifacts subdirectory
@@ -16,6 +18,8 @@ steps:
       TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
       CleanTargetFolder: true
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+
+# Always upload test outputs and build logs.
 - task: PublishTestResults@2
   displayName: Publish Test Results
   inputs:
@@ -26,6 +30,7 @@ steps:
     testRunTitle: ${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
   condition: always()
+
 - task: CopyFiles@2
   displayName: Prepare BuildLogs staging directory
   inputs:


### PR DESCRIPTION
Best to review without whitespace since the conversion tool removed any unnecessary indents
test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2401900&view=results
The error in the test run is being tracked by https://github.com/dotnet/arcade/issues/14560 but it does not block successful build

note- the PR validation does not use this new yml file, it uses `azure-pipelines-pr.yml` which is a dupe of the original azure-pipelines.yml definition