### PR TITLE
Duplicate All Build YAML files

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -51,19 +51,19 @@ stages:
   jobs:
 
   # Windows x64
-  - template: /eng/pipelines/jobs/windows-build.yml
+  - template: /eng/pipelines/jobs/windows-build-PR.yml
     parameters:
       name: win_x64
       targetArchitecture: x64
 
   # Windows x86
-  - template: /eng/pipelines/jobs/windows-build.yml
+  - template: /eng/pipelines/jobs/windows-build-PR.yml
     parameters:
       name: win_x86
       targetArchitecture: x86
 
   # Windows arm64
-  - template: /eng/pipelines/jobs/windows-build.yml
+  - template: /eng/pipelines/jobs/windows-build-PR.yml
     parameters:
       name: win_arm64
       targetArchitecture: arm64
@@ -74,7 +74,7 @@ stages:
     dependsOn: Build
     jobs:
     # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
-    - template: /eng/pipelines/jobs/prepare-signed-artifacts.yml
+    - template: /eng/pipelines/jobs/prepare-signed-artifacts-PR.yml
       parameters:
         PublishRidAgnosticPackagesFromJobName: win_x64
     # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.

--- a/eng/pipelines/jobs/prepare-signed-artifacts-PR.yml
+++ b/eng/pipelines/jobs/prepare-signed-artifacts-PR.yml
@@ -1,0 +1,63 @@
+parameters:
+  dependsOn: []
+  PublishRidAgnosticPackagesFromJobName: ''
+
+jobs:
+- job: PrepareSignedArtifacts
+  displayName: Prepare Signed Artifacts
+  dependsOn: ${{ parameters.dependsOn }}
+  pool:
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals windows.vs2019.amd64
+  # Double the default timeout.
+  timeoutInMinutes: 120
+  workspace:
+    clean: all
+
+  steps:
+
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: NuGetAuthenticate@1
+
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild plugin for Signing
+      inputs:
+        signType: $(SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      condition: and(succeeded(),
+                     in(variables['SignType'], 'real', 'test'))
+
+  - task: DownloadBuildArtifacts@0
+    displayName: Download IntermediateUnsignedArtifacts
+    inputs:
+      artifactName: IntermediateUnsignedArtifacts
+      downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
+
+  - script: >
+      build.cmd -ci
+      -projects $(Build.SourcesDirectory)\src\publish\prepare-artifacts.proj
+      -c Release
+      /p:PublishRidAgnosticPackagesFromJobName=${{ parameters.PublishRidAgnosticPackagesFromJobName }}
+      /p:SignType=$(SignType)
+      /p:DotNetSignType=$(SignType)
+      /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+    displayName: Prepare artifacts and upload to build
+
+  - task: CopyFiles@2
+    displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)'
+      Contents: |
+        **/*.log
+        **/*.binlog
+      TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
+    continueOnError: true
+    condition: succeededOrFailed()
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Artifact BuildLogs
+    inputs:
+      PathtoPublish: '$(Build.StagingDirectory)\BuildLogs'
+      ArtifactName: Logs-PrepareSignedArtifacts
+    condition: succeededOrFailed()

--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -1,0 +1,89 @@
+parameters:
+  additionalMSBuildArguments: ''
+  displayName: ''
+  skipTests: $(SkipTests)
+  targetArchitecture: null
+  timeoutInMinutes: 120
+
+jobs:
+  - job: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    pool:
+      # Use a hosted pool when possible.
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        vmImage: 'windows-2019'
+      ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals windows.vs2019.amd64
+    strategy:
+      matrix: 
+        Debug:
+          _BuildConfig: Debug
+        Release:
+          _BuildConfig: Release
+    workspace:
+      clean: all
+    variables: 
+      - name: CommonMSBuildArgs
+        value: >-
+          -c $(_BuildConfig)
+          /p:OfficialBuildId=$(OfficialBuildId)
+          /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+          /p:SkipTests=${{ parameters.skipTests }}
+      - name: MsbuildSigningArguments
+        value: /p:DotNetSignType=$(SignType)
+      - name: TargetArchitecture
+        value: ${{ parameters.targetArchitecture }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - name: _InternalRuntimeDownloadArgs
+          value: ''
+      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        - group: DotNet-MSRC-Storage
+        - name: _InternalRuntimeDownloadArgs
+          value: >-
+            /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
+            /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+
+    steps:
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - task: NuGetAuthenticate@1
+
+      - task: PowerShell@2
+        displayName: Setup Private Feeds Credentials
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+        env:
+          Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+      - task: MicroBuildSigningPlugin@2
+        displayName: Install MicroBuild plugin for Signing
+        inputs:
+          signType: $(SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+        continueOnError: false
+        condition: and(succeeded(), 
+                       in(variables['SignType'], 'real', 'test'))
+    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
+    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
+    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
+      displayName: Clear NuGet http cache (if exists)
+
+    - script: >-
+        build.cmd -ci -test
+        $(CommonMSBuildArgs)
+        $(MsbuildSigningArguments)
+        $(_InternalRuntimeDownloadArgs)
+      displayName: Build
+
+    # Generate SBOM for the internal leg only
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: ..\..\common\templates\steps\generate-sbom.yml
+        parameters:
+          name: Generate_SBOM_${{ parameters.name }}
+
+    - template: /eng/pipelines/steps/upload-job-artifacts-PR.yml
+      parameters:
+        name: ${{ parameters.name }}

--- a/eng/pipelines/steps/upload-job-artifacts-PR.yml
+++ b/eng/pipelines/steps/upload-job-artifacts-PR.yml
@@ -1,0 +1,56 @@
+parameters:
+  name: ''
+
+steps:
+# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - task: CopyFiles@2
+    displayName: Prepare job-specific Artifacts subdirectory
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+      Contents: |
+        Shipping/**/*
+        NonShipping/**/*
+      TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
+      CleanTargetFolder: true
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Artifacts
+    inputs:
+      pathToPublish: '$(Build.StagingDirectory)/Artifacts'
+      artifactName: IntermediateUnsignedArtifacts
+      artifactType: container
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+
+# Always upload test outputs and build logs.
+- task: PublishTestResults@2
+  displayName: Publish Test Results
+  inputs:
+    testResultsFormat: 'xUnit'
+    testResultsFiles: '*.xml'
+    searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+    mergeTestResults: true
+    testRunTitle: ${{ parameters.name }}-$(_BuildConfig)
+  continueOnError: true
+  condition: always()
+
+- task: CopyFiles@2
+  displayName: Prepare BuildLogs staging directory
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: |
+      **/*.log
+      **/*.binlog
+    TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
+    CleanTargetFolder: true
+  continueOnError: true
+  condition: succeededOrFailed()
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish BuildLogs
+  inputs:
+    PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
+    ArtifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
+  continueOnError: true
+  condition: succeededOrFailed()


### PR DESCRIPTION
Follow up to https://github.com/dotnet/windowsdesktop/pull/4203. We need to duplicate our other build yamls fr the pipeline migration so our PR validation continue to use original definition.