### PR TITLE
Stabilize the ProductVersion for the productVersion.txt files

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,21 +8,27 @@
     <PlatformName Condition="'$(TargetArchitecture)' != ''">$(TargetArchitecture)</PlatformName>
   </PropertyGroup>
 
-  <Target Name="GetProductVersion">
-    <!-- Retrieve the runtime pack product version.
+  <Target Name="GetNonStableProductVersion">
+    <!-- Retrieve the non-stable runtime pack product version.
          Don't stabilize the package version in order to retrieve the VersionSuffix. -->
     <MSBuild Projects="$(RepoRoot)src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj"
              Targets="ReturnProductVersion"
              Properties="IsShipping=false">
-      <Output TaskParameter="TargetOutputs" PropertyName="ProductVersion" />
+      <Output TaskParameter="TargetOutputs" PropertyName="NonStableProductVersion" />
     </MSBuild>
   </Target>
 
   <!-- This target only runs when EnableDefaultArtifacts=true which is a single build leg in CI. -->
   <Target Name="GenerateProductVersionFiles"
-          DependsOnTargets="GetProductVersion"
+          DependsOnTargets="GetNonStableProductVersion"
           BeforeTargets="PublishToAzureDevOpsArtifacts"
           Condition="'$(EnableDefaultArtifacts)' == 'true'">
+    <!-- Retrieve the runtime pack version -->
+    <MSBuild Projects="$(RepoRoot)src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj"
+             Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="ProductVersion" />
+    </MSBuild>
+
     <ItemGroup>
       <ProductVersionFile Include="$(ArtifactsShippingPackagesDir)productVersion.txt" />
       <ProductVersionFile Include="$(ArtifactsShippingPackagesDir)windowsdesktop-productVersion.txt" />
@@ -36,17 +42,17 @@
 
     <ItemGroup>
       <Artifact Include="@(ProductVersionFile)"
-                RelativeBlobPath="WindowsDesktop/$(ProductVersion)/%(Filename)%(Extension)" />
+                RelativeBlobPath="WindowsDesktop/$(NonStableProductVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 
   <Target Name="AddRelativeBlobPathToInstallerArtifacts"
-          DependsOnTargets="GetProductVersion"
+          DependsOnTargets="GetNonStableProductVersion"
           BeforeTargets="PublishToAzureDevOpsArtifacts"
           AfterTargets="GenerateChecksumsFromArtifacts">
     <ItemGroup>
       <Artifact Condition="'%(Artifact.PublishFlatContainer)' == 'true' and '%(Artifact.RelativeBlobPath)' == ''"
-                RelativeBlobPath="WindowsDesktop/$(ProductVersion)/%(Filename)%(Extension)" />
+                RelativeBlobPath="WindowsDesktop/$(NonStableProductVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
As discussed offline, the version in productVersion.txt should actually be stable during RTM and servicing.