### PR TITLE
Specify asset manifest name

### DIFF
--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -23,6 +23,7 @@ jobs:
       /p:DotNetPublishUsingPipelines=true
       /p:TargetArchitecture=${{ parameters.targetArchitecture }}
       /p:SkipTests=${{ parameters.skipTests }}
+      /p:AssetManifestOS=${{ parameters.name }}
   - name: MsbuildSigningArguments
     value: /p:DotNetSignType=$(SignType)
   - name: TargetArchitecture


### PR DESCRIPTION
Currently, we're not specify the asset manifest name, so asset manifests are overwriting themselves, and we only get the last published manifest. Adding this parameter should fix that