### PR TITLE
Define MsbuildSigningArguments Based on Public vs Internal

### DIFF
--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -40,7 +40,6 @@ jobs:
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - name: MsbuildSigningArguments
           value: /p:DotNetSignType=Real
-        - group: DotNet-MSRC-Storage
         - name: _InternalRuntimeDownloadArgs
           value: >-
             /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet

--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -33,9 +33,13 @@ jobs:
       - name: TargetArchitecture
         value: ${{ parameters.targetArchitecture }}
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - name: MsbuildSigningArguments
+          value: /p:DotNetSignType=$(SignType)
         - name: _InternalRuntimeDownloadArgs
           value: ''
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        - name: MsbuildSigningArguments
+          value: /p:DotNetSignType=Real
         - group: DotNet-MSRC-Storage
         - name: _InternalRuntimeDownloadArgs
           value: >-
@@ -71,6 +75,7 @@ jobs:
     - script: >-
         eng/common/cibuild.cmd
         $(CommonMSBuildArgs)
+        $(MsbuildSigningArguments)
         $(_InternalRuntimeDownloadArgs)
       displayName: Build
 

--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -34,7 +34,7 @@ jobs:
         value: ${{ parameters.targetArchitecture }}
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - name: MsbuildSigningArguments
-          value: /p:DotNetSignType=$(SignType)
+          value: /p:DotNetSignType=Test
         - name: _InternalRuntimeDownloadArgs
           value: ''
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:

--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -30,8 +30,6 @@ jobs:
           -c $(_BuildConfig)
           /p:TargetArchitecture=${{ parameters.targetArchitecture }}
           /p:SkipTests=${{ parameters.skipTests }}
-      - name: MsbuildSigningArguments
-        value: /p:DotNetSignType=$(SignType)
       - name: TargetArchitecture
         value: ${{ parameters.targetArchitecture }}
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -73,7 +71,6 @@ jobs:
     - script: >-
         eng/common/cibuild.cmd
         $(CommonMSBuildArgs)
-        $(MsbuildSigningArguments)
         $(_InternalRuntimeDownloadArgs)
       displayName: Build
 


### PR DESCRIPTION
[internal PR pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=1352) is failing because in the build phase during signing, the signing mode needs to be real for internal even if it is a dry run. Adding a conditional to set `MsbuildSigningArguments` based on if public or internal