### PR TITLE
Fix Fluent dll arcade check by adding to wpf specific references

### DIFF
--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
@@ -75,6 +75,7 @@
     <FrameworkListFileClass Include="PresentationFramework.Aero2.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.AeroLite.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.Classic.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="PresentationFramework.Fluent.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.resources.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.Luna.dll" Profile="WPF" />


### PR DESCRIPTION
Fix Fluent dll arcade check by adding to wpf specific references[ #4338](https://github.com/dotnet/windowsdesktop/pull/4338)
```
Error: .packages\microsoft.dotnet.sharedframework.sdk\9.0.0-beta.24219.5\targets\sharedfx.targets(409,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) File matches no classification: PresentationFramework.Fluent.dll

```