### PR TITLE
Add Profile for System.Private.Windows.Core

### DIFF
--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
@@ -64,7 +64,7 @@
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Input.Manipulations.resources.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Private.Windows.Core.dll"/>
+    <FrameworkListFileClass Include="System.Private.Windows.Core.dll" Profile="WindowsForms" />
   </ItemGroup>
 
   <!-- WPF specific references -->


### PR DESCRIPTION
Adding profile to System.Private.Windows.Core as it is for winforms only

This file was added in https://github.com/dotnet/windowsdesktop/pull/4227 but System.Private.Windows.Core is missing a profile, which will cause code added in https://github.com/dotnet/sdk/pull/39402 to filter out this assembly from the runtime pack when publishing self contained