### PR TITLE
[release/9.0-preview4] Add Profile for System.Private.Windows.Core (#4366)

### DIFF
--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
@@ -64,7 +64,7 @@
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Input.Manipulations.resources.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Private.Windows.Core.dll"/>
+    <FrameworkListFileClass Include="System.Private.Windows.Core.dll" Profile="WindowsForms" />
   </ItemGroup>
 
   <!-- WPF specific references -->


### PR DESCRIPTION
Backport of https://github.com/dotnet/windowsdesktop/pull/4366

## Customer Impact

- [X] Customer reported at https://github.com/dotnet/winforms/issues/11282
- [X] Found internally https://github.com/dotnet/sdk/issues/40173

WinForms apps no longer works when publishing a self contained app as it is missing the System.Private.Windows.Core.dll from the publish folder

## Regression

- [X] Yes
- [ ] No

## Testing

Ran publish self contained command with changes in windowsdesktop RuntimeList.xml that will be produced from this change to confirm that self contained winforms app will run as expected.

Automated test is also being added to cover this issue in https://github.com/dotnet/sdk/pull/40708

## Risk

Low - this change adds a profile to System.Private.Windows.Core.dll to specify that this is needed for winforms so that it is not filtered out from the publish folder when publishing self contained winforms app