### PR TITLE
Call NuGetAuthenticate after SetupNuGetSources

### DIFF
--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -47,8 +47,6 @@ jobs:
 
     steps:
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: NuGetAuthenticate@1
-
       - task: PowerShell@2
         displayName: Setup Private Feeds Credentials
         inputs:
@@ -56,6 +54,7 @@ jobs:
           arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
         env:
           Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - task: NuGetAuthenticate@1
 
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin for Signing

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -41,8 +41,6 @@ jobs:
       targetPath: '$(Build.StagingDirectory)/BuildLogs'
       artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
   steps:
-  - task: NuGetAuthenticate@1
-
   - task: PowerShell@2
     displayName: Setup Private Feeds Credentials
     inputs:
@@ -50,6 +48,7 @@ jobs:
       arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
     env:
       Token: $(dn-bot-dnceng-artifact-feeds-rw)
+  - task: NuGetAuthenticate@1
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing


### PR DESCRIPTION
The new version of the powershell script will not place the creds in the nuget.config file, instead it will use standard environment variables. Update the YAML file to use NuGetAuthenticate to avoid a build break that may happen if the credential provider is not available.