### PR TITLE
Use templates to enable internal sources

### DIFF
--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -35,27 +35,14 @@ jobs:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - name: MsbuildSigningArguments
           value: /p:DotNetSignType=Test
-        - name: _InternalRuntimeDownloadArgs
-          value: ''
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - name: MsbuildSigningArguments
           value: /p:DotNetSignType=Real
-        - name: _InternalRuntimeDownloadArgs
-          value: >-
-            /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
-            /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
     steps:
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - task: NuGetAuthenticate@1
+    - template: /eng/common/templates/steps/enable-internal-sources.yml
 
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin for Signing
         inputs:
@@ -63,18 +50,12 @@ jobs:
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
         continueOnError: false
-        condition: and(succeeded(), 
-                       in(variables['SignType'], 'real', 'test'))
-    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
-    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
-    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
-      displayName: Clear NuGet http cache (if exists)
+        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
 
     - script: >-
         eng/common/cibuild.cmd
         $(CommonMSBuildArgs)
         $(MsbuildSigningArguments)
-        $(_InternalRuntimeDownloadArgs)
       displayName: Build
 
     - ${{ if ne(parameters.skipTests, 'true') }}:

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -27,11 +27,6 @@ jobs:
     value: /p:DotNetSignType=$(SignType)
   - name: TargetArchitecture
     value: ${{ parameters.targetArchitecture }}
-  - group: DotNet-MSRC-Storage
-  - name: _InternalRuntimeDownloadArgs
-    value: >-
-      /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
-      /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
   templateContext:
     outputs:
@@ -41,14 +36,7 @@ jobs:
       targetPath: '$(Build.StagingDirectory)/BuildLogs'
       artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
   steps:
-  - task: PowerShell@2
-    displayName: Setup Private Feeds Credentials
-    inputs:
-      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-    env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
-  - task: NuGetAuthenticate@1
+  - template: /eng/common/templates-official/steps/enable-internal-sources.yml
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing
@@ -58,16 +46,11 @@ jobs:
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
     continueOnError: false
     condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
-    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
-  - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
-    displayName: Clear NuGet http cache (if exists)
 
   - script: >-
       eng/common/cibuild.cmd
       $(CommonMSBuildArgs)
       $(MsbuildSigningArguments)
-      $(_InternalRuntimeDownloadArgs)
     displayName: Build
 
     # Generate SBOM


### PR DESCRIPTION
Also, remove the internal runtime download args. They weren't correct (or used).