### PR TITLE
[release/6.0] Additional cleanup

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -58,4 +58,3 @@ stages:
     parameters:
       name: Windows_arm64
       targetArchitecture: arm64
-      disableVSPublish: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,6 @@ extends:
         parameters:
           name: Windows_arm64
           targetArchitecture: arm64
-          disableVSPublish: true
     - stage: PrepareForPublish
       displayName: Prepare for Publish
       dependsOn: Build

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -38,17 +38,6 @@ jobs:
         value: /p:DotNetSignType=$(SignType)
       - name: TargetArchitecture
         value: ${{ parameters.targetArchitecture }}
-      - name: DisableVSPublish
-        value: ${{ parameters.disableVSPublish }}
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - name: _InternalRuntimeDownloadArgs
-          value: ''
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - group: DotNet-MSRC-Storage
-        - name: _InternalRuntimeDownloadArgs
-          value: >-
-            /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
-            /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
     steps:
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
@@ -80,7 +69,6 @@ jobs:
         build.cmd -ci -test
         $(CommonMSBuildArgs)
         $(MsbuildSigningArguments)
-        $(_InternalRuntimeDownloadArgs)
       displayName: Build
 
     - template: steps/upload-job-artifacts-PR.yml

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -5,7 +5,6 @@ parameters:
   skipTests: $(SkipTests)
   targetArchitecture: null
   timeoutInMinutes: 120
-  disableVSPublish: false
 
 jobs:
   - job: ${{ parameters.name }}

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -31,12 +31,6 @@ jobs:
     value: /p:DotNetSignType=$(SignType)
   - name: TargetArchitecture
     value: ${{ parameters.targetArchitecture }}
-  - name: DisableVSPublish
-    value: ${{ parameters.disableVSPublish }}
-  - group: DotNet-MSRC-Storage
-  - name: _InternalRuntimeDownloadArgs
-    value: >-
-      /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
   templateContext:
     outputs:
     - output: nuget
@@ -84,7 +78,6 @@ jobs:
       build.cmd -ci -test
       $(CommonMSBuildArgs)
       $(MsbuildSigningArguments)
-      $(_InternalRuntimeDownloadArgs)
     displayName: Build
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}: []

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -5,7 +5,6 @@ parameters:
   skipTests: $(SkipTests)
   targetArchitecture: null
   timeoutInMinutes: 120
-  disableVSPublish: false
 
 jobs:
 - job: ${{ parameters.name }}
@@ -33,13 +32,6 @@ jobs:
     value: ${{ parameters.targetArchitecture }}
   templateContext:
     outputs:
-    - output: nuget
-      displayName: 'Push Visual Studio NuPkgs'
-      condition: and( succeeded(), eq(variables['_BuildConfig'], 'Release'), ne(variables['DisableVSPublish'], 'true'), ne(variables['PostBuildSign'], 'true'))
-      packageParentPath: '$(Build.ArtifactStagingDirectory)'
-      packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
-      nuGetFeedType: external
-      publishFeedCredentials: 'DevDiv - VS package feed'
     - output: buildArtifacts
       displayName: 'Publish Artifacts'
       condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))


### PR DESCRIPTION
Remove additional msrc variable group refs
Remove VS Nupkgs push option (not usable since PostBuildsign is always on)
Remove dotnetclimsrc runtime installation (inactive)