### PR TITLE
Prevent appending TFM to output path to shorten directories.

### DIFF
--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
@@ -8,6 +8,7 @@
     <InstallerRuntimeIdentifiers>win-x64;win-x86;win-arm64</InstallerRuntimeIdentifiers>
     <VSInsertionShortComponentName>WindowsDesktop.TargetingPack</VSInsertionShortComponentName>
     <CreatePlatformManifest Condition="'$(PreReleaseVersionLabel)' == 'servicing'">false</CreatePlatformManifest>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <!-- 


### PR DESCRIPTION
New WinForms Analyzer assemblies exceed 256 path characters during build.
This shortens the output paths for the ref assemblies by omitting the TFM in the name.