### PR TITLE
Fixes for VMR builds

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -4,4 +4,8 @@
     <ProjectToBuild Include="$(RepoRoot)Build.proj" />
   </ItemGroup>
 
+  <!-- Build M.W.C in pass 2 since it needs all of system.io.ports packages from other OSs" -->
+  <ItemGroup Condition="'$(DotNetBuild)' == 'true'">
+    <ProjectToBuild Include="$(RepoRoot)src\Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj" DotNetBuildPass="2" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -11,6 +11,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageDescription>This Windows Compatibility Pack provides access to APIs that were previously available only for .NET Framework. It can be used from both .NET as well as .NET Standard.</PackageDescription>
     <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
+    <!-- This project ends up restoring all of the runtime.system.io.ports.RID packages. -->
+    <ExcludeFromDotNetBuild Condition="'$(DotNetBuildPass)' != '2'">true</ExcludeFromDotNetBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
@@ -5,12 +5,8 @@
     <PlatformPackageType>RuntimePack</PlatformPackageType>
     <ArchiveName>windowsdesktop-runtime</ArchiveName>
     <InstallerName>windowsdesktop-runtime</InstallerName>
-    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <VSInsertionShortComponentName>WindowsDesktop.SharedFramework</VSInsertionShortComponentName>
     <RollForward>LatestPatch</RollForward>
-    <!-- Avoid downloading the apphost and runtime packs. Avoids an extra download and also a join point in VMR builds.-->
-    <EnableAppHostPackDownload>false</EnableAppHostPackDownload>
-    <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
   </PropertyGroup>
 
   <!-- References that are common to both WinForms and WPF -->

--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
@@ -8,6 +8,9 @@
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <VSInsertionShortComponentName>WindowsDesktop.SharedFramework</VSInsertionShortComponentName>
     <RollForward>LatestPatch</RollForward>
+    <!-- Avoid downloading the apphost and runtime packs. Avoids an extra download and also a join point in VMR builds.-->
+    <EnableAppHostPackDownload>false</EnableAppHostPackDownload>
+    <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
   </PropertyGroup>
 
   <!-- References that are common to both WinForms and WPF -->


### PR DESCRIPTION
Builds don't have access to bits built on other verticals except in pass 2+:
- Will fail to find the x86, x64, and arm64 host and runtime packs when building the sharedframework on x64. These downloads don't appear necessary to actually build the shared framework, so just disable them.
- Microsoft.Windows.Compatibility contains a reference to System.IO.Ports, which then references System.IO.Ports on all OSes. This needs to be built in pass 2. Disable in pass 1 and enable in pass 2 (note that pass 2 infra is not yet implemented).