### PR TITLE
Fix Profiles Attributes for Ref/Runtime Pack

### DIFF
--- a/src/windowsdesktop/src/sfx/Directory.Build.props
+++ b/src/windowsdesktop/src/sfx/Directory.Build.props
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Internal.Runtime.WindowsDesktop.Transport" />
   </ItemGroup>
 
-  <!-- Profile is intentionally undefined as this reference will be added via https://github.com/dotnet/wpf/blob/main/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props#L107 if conditions are met  -->
+  <!-- Profile is intentionally undefined so that the reference will only be included when no profile is specified i.e. both WPF and WindowsForms are in use https://github.com/dotnet/wpf/blob/bbfc24fd13804a191e20064acd599b0a359092df/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props#L45-L46 -->
   <ItemGroup>
     <FrameworkListFileClass Include="WindowsFormsIntegration.dll" />
   </ItemGroup>

--- a/src/windowsdesktop/src/sfx/Directory.Build.props
+++ b/src/windowsdesktop/src/sfx/Directory.Build.props
@@ -37,6 +37,11 @@
     <PackageReference Include="Microsoft.Internal.Runtime.WindowsDesktop.Transport" />
   </ItemGroup>
 
+  <!-- Profile is intentionally undefined as this reference will be added via https://github.com/dotnet/wpf/blob/main/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props#L107 if conditions are met  -->
+  <ItemGroup>
+    <FrameworkListFileClass Include="WindowsFormsIntegration.dll" />
+  </ItemGroup>
+
   <!-- References that are common to both WinForms and WPF -->
   <ItemGroup>
     <FrameworkListFileClass Include="Accessibility.dll" Profile="WindowsForms;WPF" />
@@ -56,7 +61,6 @@
     <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Extensions.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="WindowsFormsIntegration.dll"  Profile="WindowsForms;WPF"/>
   </ItemGroup>
 
   <!-- WPF specific references -->

--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
@@ -9,20 +9,13 @@
     <RollForward>LatestPatch</RollForward>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkListFileClass Include="WindowsFormsIntegration.resources.dll" />
+  </ItemGroup>
+
   <!-- References that are common to both WinForms and WPF -->
   <ItemGroup>
     <FrameworkListFileClass Include="System.Diagnostics.EventLog.Messages.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Xaml.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="UIAutomationClient.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="UIAutomationClientSideProviders.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="UIAutomationProvider.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="UIAutomationTypes.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="WindowsBase.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="WindowsFormsIntegration.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="PenImc_cor3.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="vcruntime140_cor3.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="wpfgfx_cor3.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Condition="'$(PlatformTarget)' != 'ARM64'" Include="D3DCompiler_47_cor3.dll" Profile="WindowsForms;WPF" />
   </ItemGroup>
 
   <!-- Windows Forms specific references -->
@@ -41,24 +34,34 @@
     <FrameworkListFileClass Include="System.Windows.Forms.Design.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.resources.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Windows.Input.Manipulations.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Private.Windows.Core.dll" Profile="WindowsForms" />
   </ItemGroup>
 
   <!-- WPF specific references -->
   <ItemGroup>
+    <FrameworkListFileClass Condition="'$(PlatformTarget)' != 'ARM64'" Include="D3DCompiler_47_cor3.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="DirectWriteForwarder.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="PenImc_cor3.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationCore.resources.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.Fluent.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.resources.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationUI.resources.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="ReachFramework.resources.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.resources.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="DirectWriteForwarder.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemCore.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemData.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemDrawing.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemXml.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemXmlLinq.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationNative_cor3.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="ReachFramework.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="System.Windows.Input.Manipulations.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="System.Xaml.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="UIAutomationClient.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="UIAutomationClientSideProviders.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="UIAutomationProvider.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="UIAutomationTypes.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="vcruntime140_cor3.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="WindowsBase.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="wpfgfx_cor3.dll" Profile="WPF" />
   </ItemGroup>
 </Project>

--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
@@ -9,6 +9,7 @@
     <RollForward>LatestPatch</RollForward>
   </PropertyGroup>
 
+  <!-- Profile is intentionally undefined so that the reference will only be included when no profile is specified i.e. both WPF and WindowsForms are in use https://github.com/dotnet/wpf/blob/bbfc24fd13804a191e20064acd599b0a359092df/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props#L45-L46 -->
   <ItemGroup>
     <FrameworkListFileClass Include="WindowsFormsIntegration.resources.dll" />
   </ItemGroup>


### PR DESCRIPTION
Related: https://github.com/dotnet/windowsdesktop/issues/4708, https://github.com/dotnet/windowsdesktop/issues/4789

In the ref pack `WindowsFormsIntegration` has profile WinForms and WPF when it should only be there when no profile is specified i.e. both `UseWindowsForms` and `UseWPF` is true as indicated in https://github.com/dotnet/wpf/blob/bbfc24fd13804a191e20064acd599b0a359092df/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props#L45-L46. This is causing issues starting in .NET 9 where when `<FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" />` is added to winUI app, it is trying to pull in System.Xaml even though WinForms doesn't reference xaml. In .NET 8 there was [no profile attribute](https://github.com/dotnet/windowsdesktop/blob/release/8.0/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj#L34) so updated to remove profile attribute here.

In the runtime pack a majority of the `FrameworkListFileClass` with profile for WPF and WinForms is WPF specific. Updated these to be WPF only.

Validation: 
- Tested that this change fixes https://github.com/dotnet/windowsdesktop/issues/4789 by doing manual changes to FrameworkList.xml found in windowsdesktop ref pack and RuntimeList.xml found under path .nuget\packages\microsoft.windowsdesktop.app.runtime.<> and observing rebuilding repro project succeeds
- Tested HW WPF/WinForms app runs as expected with manual changes to FrameworkList.xml/RuntimeList.xml
- Tested HW WPF/WinForms app with trimming turned on runs as expected with manual changes to FrameworkList.xml/RuntimeList.xml
- Tested published self contained WPF/WinForms app and produced runs .exe as expected with manual changes to FrameworkList.xml/RuntimeList.xml
- Tested WPF apps hosting WinForms controls (`UseWPF` and `UseWindowsForms` both true) runs as expected with manual changes to FrameworkList.xml/RuntimeList.xml
- Tested publishing self contained WPF app hosting WinForms controls (`UseWPF` and `UseWindowsForms` both true) and produced .exe runs as expected with manual changes to FrameworkList.xml/RuntimeList.xml
- Compared FrameworkList.xml in msi produced by windowsdesktop build before and after change shows expected diff