### PR TITLE
[release/9.0] Fix Profiles Attributes for Ref/Runtime Pack

### DIFF
--- a/src/windowsdesktop/src/sfx/Directory.Build.props
+++ b/src/windowsdesktop/src/sfx/Directory.Build.props
@@ -31,6 +31,11 @@
     <PackageReference Include="Microsoft.Internal.Runtime.WindowsDesktop.Transport" />
   </ItemGroup>
 
+  <!-- Profile is intentionally undefined so that the reference will only be included when no profile is specified i.e. both WPF and WindowsForms are in use https://github.com/dotnet/wpf/blob/bbfc24fd13804a191e20064acd599b0a359092df/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props#L45-L46 -->
+  <ItemGroup>
+    <FrameworkListFileClass Include="WindowsFormsIntegration.dll" />
+  </ItemGroup>
+
   <!-- References that are common to both WinForms and WPF -->
   <ItemGroup>
     <FrameworkListFileClass Include="Accessibility.dll" Profile="WindowsForms;WPF" />
@@ -50,7 +55,6 @@
     <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Extensions.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="WindowsFormsIntegration.dll"  Profile="WindowsForms;WPF"/>
   </ItemGroup>
 
   <!-- WPF specific references -->

--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj
@@ -10,20 +10,14 @@
     <RollForward>LatestPatch</RollForward>
   </PropertyGroup>
 
+  <!-- Profile is intentionally undefined so that the reference will only be included when no profile is specified i.e. both WPF and WindowsForms are in use https://github.com/dotnet/wpf/blob/bbfc24fd13804a191e20064acd599b0a359092df/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props#L45-L46 -->
+  <ItemGroup>
+    <FrameworkListFileClass Include="WindowsFormsIntegration.resources.dll" />
+  </ItemGroup>
+
   <!-- References that are common to both WinForms and WPF -->
   <ItemGroup>
     <FrameworkListFileClass Include="System.Diagnostics.EventLog.Messages.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Xaml.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="UIAutomationClient.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="UIAutomationClientSideProviders.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="UIAutomationProvider.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="UIAutomationTypes.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="WindowsBase.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="WindowsFormsIntegration.resources.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="PenImc_cor3.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="vcruntime140_cor3.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="wpfgfx_cor3.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Condition="'$(PlatformTarget)' != 'ARM64'" Include="D3DCompiler_47_cor3.dll" Profile="WindowsForms;WPF" />
   </ItemGroup>
 
   <!-- Windows Forms specific references -->
@@ -42,24 +36,34 @@
     <FrameworkListFileClass Include="System.Windows.Forms.Design.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.resources.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Windows.Input.Manipulations.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Private.Windows.Core.dll" Profile="WindowsForms" />
   </ItemGroup>
 
   <!-- WPF specific references -->
   <ItemGroup>
+    <FrameworkListFileClass Condition="'$(PlatformTarget)' != 'ARM64'" Include="D3DCompiler_47_cor3.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="DirectWriteForwarder.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="PenImc_cor3.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationCore.resources.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.Fluent.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.resources.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationUI.resources.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="ReachFramework.resources.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.resources.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="DirectWriteForwarder.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemCore.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemData.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemDrawing.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemXml.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework-SystemXmlLinq.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationNative_cor3.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="ReachFramework.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="System.Windows.Input.Manipulations.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="System.Xaml.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="UIAutomationClient.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="UIAutomationClientSideProviders.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="UIAutomationProvider.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="UIAutomationTypes.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="vcruntime140_cor3.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="WindowsBase.resources.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="wpfgfx_cor3.dll" Profile="WPF" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/windowsdesktop/pull/4788

## Customer Impact
Customers that have `<FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" />` in their winUI project or references packages that pulls same dlls as package Microsoft.WindowsDesktop.App.WindowsForms are no longer able to build successfully since this specifies WindowsForms profile, which now pulls in dlls that need to resolve System.Xaml when WinForms does not reference xaml. Specifically, adding the package reference now pulls in WindowsFormsIntegration.dll which should only be present when no profile is specified i.e. when users have both <UseWindowsForms> and <UseWPF> in their project. This behavior has regressed since .NET 8

Additionally, when publishing a self-contained WinForms app, customers will have unnecessary dlls present that are not used by WinForms at all.

These issues are now occurring in .NET 9 because we had updated all dlls in both the runtime/ref pack to have a specified profile to support respecting profiles when publish self-contained winforms/wpf app. In the process of doing this, we had mis profiled a few dlls causing them to be pulled in when they shouldn't be for certain scenarios.

## Testing
- Compared FrameworkList.xml in msi produced by windowsdesktop build before and after change shows expected diff
- Compared RuntimeList.xml in nupkg produced by [AzDO build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2587306&view=artifacts&pathAsName=false&type=publishedArtifacts)  before and after change shows expected diff 
- Tested that this change fixes https://github.com/dotnet/windowsdesktop/issues/4789 by doing manual updates to `FrameworkList.xml` found in windowsdesktop ref pack and `RuntimeList.xml` found under path .nuget\packages\microsoft.windowsdesktop.app.runtime.<> to be the same as above FrameworkList.xml/RuntimeList.xml and observing rebuilding repro project succeeds
- Tested Hello World (HW) WPF/WinForms app runs as expected with the manual changes to FrameworkList.xml/RuntimeList.xml
- Tested HW WPF/WinForms app with trimming turned on runs as expected with the manual changes to FrameworkList.xml/RuntimeList.xml
- Tested published self contained WPF/WinForms app and produced runs .exe as expected with the manual changes to FrameworkList.xml/RuntimeList.xml
- Tested WPF apps hosting WinForms controls (`UseWPF` and `UseWindowsForms` both true) runs as expected with the manual changes to FrameworkList.xml/RuntimeList.xml
- Tested publishing self contained WPF app hosting WinForms controls (`UseWPF` and `UseWindowsForms` both true) and produced .exe runs as expected with the manual changes to FrameworkList.xml/RuntimeList.xml

## Risk
Low. The change corrects the mis profiled dlls in the ref/runtime pack and validation in various scenarios done to make sure there are no regressions.