### PR TITLE
Use the live crossgen2 corresponding to the runtime we're building against.

### DIFF
--- a/src/windowsdesktop/src/sfx/Directory.Build.targets
+++ b/src/windowsdesktop/src/sfx/Directory.Build.targets
@@ -5,13 +5,13 @@
   <ItemGroup>
     <KnownFrameworkReference
       Update="Microsoft.NETCore.App">
-      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(TargetFramework)'">$(MicrosoftNETCoreAppRefVersion)</DefaultRuntimeFrameworkVersion>
-      <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(TargetFramework)'">$(MicrosoftNETCoreAppRefVersion)</LatestRuntimeFrameworkVersion>
-      <TargetingPackVersion Condition="'%(TargetFramework)' == '$(TargetFramework)'">$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
+      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(NetCurrent)'">$(MicrosoftNETCoreAppRefVersion)</DefaultRuntimeFrameworkVersion>
+      <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(NetCurrent)'">$(MicrosoftNETCoreAppRefVersion)</LatestRuntimeFrameworkVersion>
+      <TargetingPackVersion Condition="'%(TargetFramework)' == '$(NetCurrent)'">$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
     </KnownFrameworkReference>
     <KnownCrossgen2Pack
       Update="Microsoft.NETCore.App.Crossgen2">
-      <Crossgen2PackVersion Condition="'%(TargetFramework)' == '$(TargetFramework)'">$(MicrosoftNETCoreAppRefVersion)</Crossgen2PackVersion>
+      <Crossgen2PackVersion Condition="'%(TargetFramework)' == '$(NetCurrent)'">$(MicrosoftNETCoreAppRefVersion)</Crossgen2PackVersion>
     </KnownCrossgen2Pack>
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />

--- a/src/windowsdesktop/src/sfx/Directory.Build.targets
+++ b/src/windowsdesktop/src/sfx/Directory.Build.targets
@@ -5,13 +5,19 @@
   <ItemGroup>
     <KnownFrameworkReference
       Update="Microsoft.NETCore.App"
+      Condition="'%(TargetFramework)' == '$(TargetFramework)'"
       DefaultRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefVersion)"
       LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefVersion)"
       TargetingPackVersion="$(MicrosoftNETCoreAppRefVersion)" />
+    <KnownCrossgen2Pack
+      Update="Microsoft.NETCore.App.Crossgen2"
+      Condition="'%(TargetFramework)' == '$(TargetFramework)'"
+      Crossgen2PackVersion="$(MicrosoftNETCoreAppRefVersion)" />
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WPF" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/src/windowsdesktop/src/sfx/Directory.Build.targets
+++ b/src/windowsdesktop/src/sfx/Directory.Build.targets
@@ -4,15 +4,15 @@
 
   <ItemGroup>
     <KnownFrameworkReference
-      Update="Microsoft.NETCore.App"
-      Condition="'%(TargetFramework)' == '$(TargetFramework)'"
-      DefaultRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefVersion)"
-      LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefVersion)"
-      TargetingPackVersion="$(MicrosoftNETCoreAppRefVersion)" />
+      Update="Microsoft.NETCore.App">
+      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(TargetFramework)'">$(MicrosoftNETCoreAppRefVersion)</DefaultRuntimeFrameworkVersion>
+      <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(TargetFramework)'">$(MicrosoftNETCoreAppRefVersion)</LatestRuntimeFrameworkVersion>
+      <TargetingPackVersion Condition="'%(TargetFramework)' == '$(TargetFramework)'">$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
+    </KnownFrameworkReference>
     <KnownCrossgen2Pack
-      Update="Microsoft.NETCore.App.Crossgen2"
-      Condition="'%(TargetFramework)' == '$(TargetFramework)'"
-      Crossgen2PackVersion="$(MicrosoftNETCoreAppRefVersion)" />
+      Update="Microsoft.NETCore.App.Crossgen2">
+      <Crossgen2PackVersion Condition="'%(TargetFramework)' == '$(TargetFramework)'">$(MicrosoftNETCoreAppRefVersion)</Crossgen2PackVersion>
+    </KnownCrossgen2Pack>
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />


### PR DESCRIPTION
We've seen incompatibilities between older crossgen2 versions and newer runtimes. To ensure consistency in how we construct the product, this PR updates the reference to crossgen2 to use the live crossgen2 from dotnet/runtime.

Opening as draft as getting this working in the VMR will require work across multiple repos and I want to validate the VMR experience before merging any of the changes.