### PR TITLE
Update to newer MicroBuild plugin

### DIFF
--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -43,7 +43,7 @@ jobs:
     - template: /eng/common/templates/steps/enable-internal-sources.yml
 
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: MicroBuildSigningPlugin@2
+      - task: MicroBuildSigningPlugin@4
         displayName: Install MicroBuild plugin for Signing
         inputs:
           signType: $(SignType)

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -38,7 +38,7 @@ jobs:
   steps:
   - template: /eng/common/templates-official/steps/enable-internal-sources.yml
 
-  - task: MicroBuildSigningPlugin@2
+  - task: MicroBuildSigningPlugin@4
     displayName: Install MicroBuild plugin for Signing
     inputs:
       signType: $(SignType)


### PR DESCRIPTION
Unblocks the broken official builds in windowsdesktop. The "PR" yml probably doesn't need this whole block at all but I wanted to keep this scoped.