### PR TITLE
[release/9.0] Update MicroBuild to v4

### DIFF
--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -43,7 +43,7 @@ jobs:
     - template: /eng/common/templates/steps/enable-internal-sources.yml
 
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: MicroBuildSigningPlugin@2
+      - task: MicroBuildSigningPlugin@4
         displayName: Install MicroBuild plugin for Signing
         inputs:
           signType: $(SignType)

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -38,7 +38,7 @@ jobs:
   steps:
   - template: /eng/common/templates-official/steps/enable-internal-sources.yml
 
-  - task: MicroBuildSigningPlugin@2
+  - task: MicroBuildSigningPlugin@4
     displayName: Install MicroBuild plugin for Signing
     inputs:
       signType: $(SignType)


### PR DESCRIPTION
Infrastructure change only. This change updates MicroBuild version to get CI build passing for release/9.0 as it currently fails due to out of date MicroBuild version

Same changes done to main in https://github.com/dotnet/windowsdesktop/pull/4822