### PR TITLE
[release/8.0] Update MicroBuild to v4

### DIFF
--- a/eng/pipelines/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/jobs/prepare-signed-artifacts.yml
@@ -20,7 +20,7 @@ jobs:
   steps:
   - task: NuGetAuthenticate@1
 
-  - task: MicroBuildSigningPlugin@2
+  - task: MicroBuildSigningPlugin@4
     displayName: Install MicroBuild plugin for Signing
     inputs:
       signType: $(SignType)

--- a/eng/pipelines/jobs/windows-build-PR.yml
+++ b/eng/pipelines/jobs/windows-build-PR.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-      - task: MicroBuildSigningPlugin@2
+      - task: MicroBuildSigningPlugin@4
         displayName: Install MicroBuild plugin for Signing
         inputs:
           signType: $(SignType)

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -52,7 +52,7 @@ jobs:
     env:
       Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-  - task: MicroBuildSigningPlugin@2
+  - task: MicroBuildSigningPlugin@4
     displayName: Install MicroBuild plugin for Signing
     inputs:
       signType: $(SignType)


### PR DESCRIPTION
Infrastructure change only. This change updates MicroBuild version to get CI build passing for release/8.0 as it currently fails due to out of date MicroBuild version

Same changes done to main in https://github.com/dotnet/windowsdesktop/pull/4822