### PR TITLE
Update Windows.Compatibility external packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MicrosoftDotNetBuildTasksInstallersVersion>10.0.0-beta.25076.1</MicrosoftDotNetBuildTasksInstallersVersion>
     <!-- corefx -->
     <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>
-    <SystemDataSqlClientVersion>4.8.6</SystemDataSqlClientVersion>
+    <SystemDataSqlClientVersion>4.9.0</SystemDataSqlClientVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
@@ -60,7 +60,7 @@
     <SystemThreadingAccessControlVersion>10.0.0-alpha.1.25073.13</SystemThreadingAccessControlVersion>
     <VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>10.0.0-alpha.1.25073.13</VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>
     <!-- wcf -->
-    <SystemServiceModelVersion>4.10.0</SystemServiceModelVersion>
+    <SystemServiceModelVersion>8.1.1</SystemServiceModelVersion>
     <!-- winforms -->
     <MicrosoftPrivateWinformsVersion>10.0.0-alpha.1.25076.1</MicrosoftPrivateWinformsVersion>
     <SystemDrawingCommonVersion>10.0.0-alpha.1.25076.1</SystemDrawingCommonVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
     <SystemThreadingAccessControlVersion>10.0.0-alpha.1.25073.13</SystemThreadingAccessControlVersion>
     <VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>10.0.0-alpha.1.25073.13</VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>
     <!-- wcf -->
-    <SystemServiceModelVersion>8.1.1</SystemServiceModelVersion>
+    <SystemServiceModelVersion>6.0.0</SystemServiceModelVersion>
     <!-- winforms -->
     <MicrosoftPrivateWinformsVersion>10.0.0-alpha.1.25076.1</MicrosoftPrivateWinformsVersion>
     <SystemDrawingCommonVersion>10.0.0-alpha.1.25076.1</SystemDrawingCommonVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
     <SystemThreadingAccessControlVersion>10.0.0-alpha.1.25073.13</SystemThreadingAccessControlVersion>
     <VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>10.0.0-alpha.1.25073.13</VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>
     <!-- wcf -->
-    <SystemServiceModelVersion>6.0.0</SystemServiceModelVersion>
+    <SystemServiceModelVersion>8.1.1</SystemServiceModelVersion>
     <!-- winforms -->
     <MicrosoftPrivateWinformsVersion>10.0.0-alpha.1.25076.1</MicrosoftPrivateWinformsVersion>
     <SystemDrawingCommonVersion>10.0.0-alpha.1.25076.1</SystemDrawingCommonVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,6 +15,10 @@
     <MicrosoftDotNetBuildTasksInstallersVersion>10.0.0-beta.25076.1</MicrosoftDotNetBuildTasksInstallersVersion>
     <!-- corefx -->
     <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>
+    <!-- The SQL team had deprecated System.Data.SqlClient package and replaced it with Microsoft.Data.SqlClient.
+     However, windows compatibility package should not include Microsoft.Data.SqlClient since that's not part of .NETFramework surface area.
+     The purpose of Microsoft.Windows.Compatibility is to bring assemblies that implement the actual types from .NETFramework
+     that aren't inbox on .NET. It is not meant to "advertise" new types/packages that were not part of .NETFramework. -->
     <SystemDataSqlClientVersion>4.9.0</SystemDataSqlClientVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>

--- a/src/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -45,11 +45,9 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="System.Security.Permissions" />
-    <PackageReference Include="System.ServiceModel.Duplex" />
     <PackageReference Include="System.ServiceModel.Http" />
     <PackageReference Include="System.ServiceModel.NetTcp" />
     <PackageReference Include="System.ServiceModel.Primitives" />
-    <PackageReference Include="System.ServiceModel.Security" />
     <PackageReference Include="System.ServiceModel.Syndication" />
     <PackageReference Include="System.ServiceProcess.ServiceController" />
     <PackageReference Include="System.Speech" />


### PR DESCRIPTION
@cheenamalhotra  - SQLClient
@HongGit @StephenMolloy @mconnew - WCF client

Please review if these dependency changes are correct for .NET 10.0.

Also please comment on what changes, if any, would be appropriate to backport to `net9.0` or `net.8.0`.