### PR TITLE
[release/9.0] Update Windows.Compatibility external packages.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <MicrosoftDotNetBuildTasksInstallersVersion>9.0.0-beta.25255.5</MicrosoftDotNetBuildTasksInstallersVersion>
     <!-- corefx -->
     <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>
-    <SystemDataSqlClientVersion>4.8.6</SystemDataSqlClientVersion>
+    <SystemDataSqlClientVersion>4.9.0</SystemDataSqlClientVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
@@ -61,7 +61,7 @@
     <SystemThreadingAccessControlVersion>9.0.4</SystemThreadingAccessControlVersion>
     <VSRedistCommonNetCoreSharedFrameworkx6490PackageVersion>9.0.4-servicing.25163.5</VSRedistCommonNetCoreSharedFrameworkx6490PackageVersion>
     <!-- wcf -->
-    <SystemServiceModelVersion>4.10.0</SystemServiceModelVersion>
+    <SystemServiceModelVersion>4.10.3</SystemServiceModelVersion>
     <!-- winforms -->
     <MicrosoftPrivateWinformsVersion>9.0.4-servicing.25163.12</MicrosoftPrivateWinformsVersion>
     <SystemDrawingCommonVersion>9.0.4</SystemDrawingCommonVersion>


### PR DESCRIPTION
Related to https://github.com/dotnet/windowsdesktop/pull/4884

## Description:
An internal partner reported that Microsoft.Windows.Compatibility NuGet v8.0.12 package carries 3 assemblies(System.Data.SqlClient.dll, System.Diagnostics.EventLog.Messages.dll, and System.ServiceModel.dll) that do not have symbols on the Microsoft symbol server. The issue is not blocking for the partner, but we want to take this opportunity to update these packages to the newer, supported versions of external packages.

## Fix:
System.Data.SqlClient.dll – updated to a newer compatibility package that has symbols
System.ServiceModel.dll - updated to a newer compatible package that is in support because it ships with the PowerShell. This package does not have symbols. The only WCF package that has symbols is V8 and introduces breaking changes.
System.Diagnostics.EventLog.Messages.dll – pdbs had been already added [[release/9.0-staging] Include PDB for all TfmRuntimeSpecificPackageFile by github-actions[bot] · Pull Request #112139 · dotnet/runtime](https://github.com/dotnet/runtime/pull/112139)
 
## Followup bugs
[Symbol package questions · Issue dotnet/runtime#15457 · dotnet/arcade](https://github.com/dotnet/arcade/issues/15457)
[What is the expected workflow for Symbols Validation of official releases? · Issue dotnet/arcade#15537 · dotnet/runtime](https://github.com/dotnet/arcade/issues/15537)

## Customer Impact:
Windows partner has to store pdbs locally to be accessible for the duration of windows support term, which is longer that the .NET8’s. To achieve this goal, they are down loading pdbs from the symbol server, their script breaks on our package. They can’t upgrade to NET10, but can reverence the newer versions of these packages directly in their project.

## Testing:
built the windows compatibility pack and verified that the right package versions are referenced.

## Risk:
Low