### PR TITLE
Update Nuget.Packaging version to avoid dependency on System.Formats.Asn1 v8.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,11 +58,9 @@
     <PackageVersion Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
 
     <!-- WCF dependencies -->
-    <PackageVersion Include="System.ServiceModel.Duplex" Version="$(SystemServiceModelVersion)" />
     <PackageVersion Include="System.ServiceModel.Http" Version="$(SystemServiceModelVersion)" />
     <PackageVersion Include="System.ServiceModel.NetTcp" Version="$(SystemServiceModelVersion)" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="$(SystemServiceModelVersion)" />
-    <PackageVersion Include="System.ServiceModel.Security" Version="$(SystemServiceModelVersion)" />
     <PackageVersion Include="System.Web.Services.Description" Version="$(SystemServiceModelVersion)" />
 
     <!-- WinForms dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
     <!-- nuget -->
-    <NuGetPackagingVersion>6.8.1</NuGetPackagingVersion>
+    <NuGetPackagingVersion>6.12.1</NuGetPackagingVersion>
     <!-- runtime -->
     <MicrosoftInternalRuntimeWindowsDesktopTransportVersion>10.0.0-preview.2.25104.8</MicrosoftInternalRuntimeWindowsDesktopTransportVersion>
     <MicrosoftNETCoreAppRefVersion>10.0.0-preview.2.25104.8</MicrosoftNETCoreAppRefVersion>


### PR DESCRIPTION
nuget.packaging depends on cryptography and cryptography depends on Asn1 format. The newer version of nuget.packaging pulls in the newer cryptography package.

![image](https://github.com/user-attachments/assets/673ef029-1900-486a-81cb-bf38cb28a8e6)

![image](https://github.com/user-attachments/assets/bf5366fd-7769-419f-9aa3-f09d58e44ff8)

I think that System.io.packaging and System.runtime.caching were false positives as they have versions set to 10 in Versions.Props.

Fixes https://github.com/dotnet/windowsdesktop/issues/4917