### PR TITLE
Deduplidate assets in VMR builds

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,6 +8,21 @@
     <PlatformName Condition="'$(TargetArchitecture)' != ''">$(TargetArchitecture)</PlatformName>
   </PropertyGroup>
 
+  <!--
+    Only generate the productVersion.txt and windowsdesktop-productVersion.txt files when we're building
+    either the full VMR repo or not building in the VMR infrastructure.
+    This ensures that we don't produce these files in the "Repo source build" builds,
+    but we do produce them in both the VMR and the runtime official build.
+  -->
+  <PropertyGroup Condition="'$(DotNetBuildOrchestrator)' == 'true'">
+    <ShouldGenerateProductVersionFiles Condition="'$(EnableDefaultRidSpecificArtifacts)' != 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">true</ShouldGenerateProductVersionFiles>
+    <ShouldGenerateProductVersionFiles Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</ShouldGenerateProductVersionFiles>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DotNetBuildOrchestrator)' != 'true'">
+    <ShouldGenerateProductVersionFiles Condition="'$(EnableDefaultArtifacts)' == 'true'">true</ShouldGenerateProductVersionFiles>
+  </PropertyGroup>
+
   <Target Name="GetNonStableProductVersion">
     <!-- Retrieve the non-stable runtime pack product version.
          Don't stabilize the package version in order to retrieve the VersionSuffix. -->
@@ -22,7 +37,7 @@
   <Target Name="GenerateProductVersionFiles"
           DependsOnTargets="GetNonStableProductVersion"
           BeforeTargets="PublishToAzureDevOpsArtifacts"
-          Condition="'$(EnableDefaultArtifacts)' == 'true'">
+          Condition="'$(ShouldGenerateProductVersionFiles)' == 'true'">
     <!-- Retrieve the runtime pack version -->
     <MSBuild Projects="$(RepoRoot)src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj"
              Targets="ReturnProductVersion">

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -14,13 +14,9 @@
     This ensures that we don't produce these files in the "Repo source build" builds,
     but we do produce them in both the VMR and the runtime official build.
   -->
-  <PropertyGroup Condition="'$(DotNetBuildOrchestrator)' == 'true'">
-    <ShouldGenerateProductVersionFiles Condition="'$(EnableDefaultRidSpecificArtifacts)' != 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">true</ShouldGenerateProductVersionFiles>
-    <ShouldGenerateProductVersionFiles Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</ShouldGenerateProductVersionFiles>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(DotNetBuildOrchestrator)' != 'true'">
-    <ShouldGenerateProductVersionFiles Condition="'$(EnableDefaultArtifacts)' == 'true'">true</ShouldGenerateProductVersionFiles>
+  <PropertyGroup>
+    <ShouldGenerateProductVersionFiles Condition="'$(DotNetBuildOrchestrator)' == 'true' and '$(EnableDefaultRidSpecificArtifacts)' != 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">true</ShouldGenerateProductVersionFiles>
+    <ShouldGenerateProductVersionFiles Condition="'$(DotNetBuildOrchestrator)' != 'true' and '$(EnableDefaultArtifacts)' == 'true'">true</ShouldGenerateProductVersionFiles>
   </PropertyGroup>
 
   <Target Name="GetNonStableProductVersion">


### PR DESCRIPTION
# Deduplidate assets produced on multiple build legs in the VMR

As part of moving way from a "primary" vertical concept in the VMR, we need to deduplicate the version files that windowsdesktop produces in the VMR builds. This PR provides that infrastructure.

## Description

Changes the version files to be published in the VMR only when we're publishing all artifacts, not only RID-specific ones.

Contributes to https://github.com/dotnet/source-build/issues/4905
