### PR TITLE
Add hardcoded PackageOverrides list

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <!-- Arcade dependencies -->
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersVersion)" />
-    <PacakgeVersion Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
 
     <!-- CoreFx dependencies -->
     <PackageVersion Include="System.Data.DataSetExtensions" Version="$(SystemDataDataSetExtensionsVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <!-- Arcade dependencies -->
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersVersion)" />
+    <PacakgeVersion Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
 
     <!-- CoreFx dependencies -->
     <PackageVersion Include="System.Data.DataSetExtensions" Version="$(SystemDataDataSetExtensionsVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -164,6 +164,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>1560b3406a8ebf9e267f7a1dddbf5238dd378081</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="10.0.0-beta.25175.4">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>1560b3406a8ebf9e267f7a1dddbf5238dd378081</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="10.0.0-beta.25175.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>1560b3406a8ebf9e267f7a1dddbf5238dd378081</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,6 +13,7 @@
     <!-- arcade -->
     <MicrosoftDotNetBuildTasksArchivesVersion>10.0.0-beta.25175.4</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>10.0.0-beta.25175.4</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>10.0.0-beta.25175.4</MicrosoftDotNetBuildTasksTemplatingVersion>
     <!-- corefx -->
     <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>
     <!-- The SQL team had deprecated System.Data.SqlClient package and replaced it with Microsoft.Data.SqlClient.

--- a/src/windowsdesktop/src/sfx/Directory.Build.props
+++ b/src/windowsdesktop/src/sfx/Directory.Build.props
@@ -89,7 +89,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" />
   </ItemGroup>
 
 </Project>

--- a/src/windowsdesktop/src/sfx/Directory.Build.props
+++ b/src/windowsdesktop/src/sfx/Directory.Build.props
@@ -88,4 +88,8 @@
     <FrameworkListFileClass Include="WindowsBase.dll" Profile="WPF" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/src/windowsdesktop/src/sfx/Directory.Build.targets
+++ b/src/windowsdesktop/src/sfx/Directory.Build.targets
@@ -48,4 +48,24 @@
 
   <Target Name="ReturnProductVersion" Returns="$(Version)" />
 
+  <Target Name="CreatePackageOverrides">
+    <PropertyGroup>
+      <PackageOverridesInputPath>$(MSBuildThisFileDirectory)PackageOverrides.txt</PackageOverridesInputPath>
+      <PackageOverridesOutputPath>$(BaseOutputPath)PackageOverrides.txt</PackageOverridesOutputPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <CreatePackageOverridesTemplateProperty Include="ProductVersion=$(Version)" />
+    </ItemGroup>
+
+    <GenerateFileFromTemplate
+      TemplateFile="$(PackageOverridesInputPath)"
+      Properties="@(CreatePackageOverridesTemplateProperty)"
+      OutputPath="$(PackageOverridesOutputPath)" />
+
+    <ItemGroup>
+      <PackageOverridesFile Include="$(PackageOverridesOutputPath)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/windowsdesktop/src/sfx/PackageOverrides.txt
+++ b/src/windowsdesktop/src/sfx/PackageOverrides.txt
@@ -1,0 +1,16 @@
+Microsoft.Win32.Registry.AccessControl|${ProductVersion}
+Microsoft.Win32.SystemEvents|${ProductVersion}
+System.CodeDom|${ProductVersion}
+System.Configuration.ConfigurationManager|${ProductVersion}
+System.Diagnostics.EventLog|${ProductVersion}
+System.Diagnostics.PerformanceCounter|${ProductVersion}
+System.DirectoryServices|${ProductVersion}
+System.Drawing.Common|${ProductVersion}
+System.Formats.Nrbf|${ProductVersion}
+System.IO.Packaging|${ProductVersion}
+System.Security.Cryptography.Pkcs|${ProductVersion}
+System.Security.Cryptography.ProtectedData|${ProductVersion}
+System.Security.Cryptography.Xml|${ProductVersion}
+System.Security.Permissions|${ProductVersion}
+System.Threading.AccessControl|${ProductVersion}
+System.Windows.Extensions|${ProductVersion}


### PR DESCRIPTION
Fixes https://github.com/dotnet/windowsdesktop/issues/4904

We should at some point validate that the list isn't missing packages. Example: When runtime adds a new assembly to the windowsdesktop transport pack.

This is 1:1 translation of this data source: https://github.com/dotnet/runtime/blob/0b6e62e8343697ad31cdbe8f84f8b9e594973b97/src/libraries/NetCoreAppLibrary.props#L229-L246