### PR TITLE
Update Versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
     <SystemThreadingAccessControlVersion>10.0.0-preview.4.25221.6</SystemThreadingAccessControlVersion>
     <VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>10.0.0-preview.4.25221.6</VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>
     <!-- wcf -->
-    <SystemServiceModelVersion>8.1.1</SystemServiceModelVersion>
+    <SystemServiceModelVersion>8.1.2</SystemServiceModelVersion>
     <!-- winforms -->
     <MicrosoftPrivateWinformsVersion>10.0.0-preview.5.25222.5</MicrosoftPrivateWinformsVersion>
     <SystemDrawingCommonVersion>10.0.0-preview.5.25222.5</SystemDrawingCommonVersion>


### PR DESCRIPTION
Related to https://github.com/dotnet/windowsdesktop/issues/4885 A newer version of WCF client is available on nuget now. This version has fixes that WCF team wants to ship in the desktop package because it contains additional type forwards.