### PR TITLE
Auto-generate parts of the PackageOverrides file

### DIFF
--- a/src/windowsdesktop/src/sfx/Directory.Build.targets
+++ b/src/windowsdesktop/src/sfx/Directory.Build.targets
@@ -52,10 +52,14 @@
     <PropertyGroup>
       <PackageOverridesInputPath>$(MSBuildThisFileDirectory)PackageOverrides.txt</PackageOverridesInputPath>
       <PackageOverridesOutputPath>$(BaseOutputPath)PackageOverrides.txt</PackageOverridesOutputPath>
+
+      <!-- Add the RuntimeWindowsDesktopPackageLibrary item information from the Microsoft.Internal.Runtime.WindowsDesktop.Transport package. -->
+      <RuntimeWindowsDesktopPackageLibraries>@(RuntimeWindowsDesktopPackageLibrary->'%(PackageId)|%(PackageVersion)', '
+')</RuntimeWindowsDesktopPackageLibraries>
     </PropertyGroup>
 
     <ItemGroup>
-      <CreatePackageOverridesTemplateProperty Include="ProductVersion=$(Version)" />
+      <CreatePackageOverridesTemplateProperty Include="RuntimeWindowsDesktopPackageLibraries=$(RuntimeWindowsDesktopPackageLibraries)" />
     </ItemGroup>
 
     <GenerateFileFromTemplate

--- a/src/windowsdesktop/src/sfx/PackageOverrides.txt
+++ b/src/windowsdesktop/src/sfx/PackageOverrides.txt
@@ -1,16 +1,1 @@
-Microsoft.Win32.Registry.AccessControl|${ProductVersion}
-Microsoft.Win32.SystemEvents|${ProductVersion}
-System.CodeDom|${ProductVersion}
-System.Configuration.ConfigurationManager|${ProductVersion}
-System.Diagnostics.EventLog|${ProductVersion}
-System.Diagnostics.PerformanceCounter|${ProductVersion}
-System.DirectoryServices|${ProductVersion}
-System.Drawing.Common|${ProductVersion}
-System.Formats.Nrbf|${ProductVersion}
-System.IO.Packaging|${ProductVersion}
-System.Security.Cryptography.Pkcs|${ProductVersion}
-System.Security.Cryptography.ProtectedData|${ProductVersion}
-System.Security.Cryptography.Xml|${ProductVersion}
-System.Security.Permissions|${ProductVersion}
-System.Threading.AccessControl|${ProductVersion}
-System.Windows.Extensions|${ProductVersion}
+${RuntimeWindowsDesktopPackageLibraries}


### PR DESCRIPTION
Fixes https://github.com/dotnet/windowsdesktop/issues/4998

Depends on https://github.com/dotnet/runtime/pull/115477