### PR TITLE
Replace arch-specific package properties with arch neutral ones

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,11 +22,7 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>85778473549347b3e4bad3ea009e9438df7b11bb</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.10.0" Version="10.0.0-preview.5.25260.104">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>85778473549347b3e4bad3ea009e9438df7b11bb</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="10.0.0-preview.5.25260.104">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="10.0.0-preview.5.25260.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>85778473549347b3e4bad3ea009e9438df7b11bb</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
     <!-- runtime -->
     <MicrosoftInternalRuntimeWindowsDesktopTransportVersion>10.0.0-preview.5.25260.104</MicrosoftInternalRuntimeWindowsDesktopTransportVersion>
     <MicrosoftNETCoreAppRefVersion>10.0.0-preview.5.25260.104</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>10.0.0-preview.5.25260.104</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCorePlatformsVersion>10.0.0-preview.5.25260.104</MicrosoftNETCorePlatformsVersion>
     <MicrosoftWin32RegistryAccessControlVersion>10.0.0-preview.5.25260.104</MicrosoftWin32RegistryAccessControlVersion>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <MicrosoftWin32SystemEventsVersion>10.0.0-preview.5.25260.104</MicrosoftWin32SystemEventsVersion>
@@ -67,7 +67,6 @@
     <SystemSpeechVersion>10.0.0-preview.5.25260.104</SystemSpeechVersion>
     <SystemTextEncodingCodePagesVersion>10.0.0-preview.5.25260.104</SystemTextEncodingCodePagesVersion>
     <SystemThreadingAccessControlVersion>10.0.0-preview.5.25260.104</SystemThreadingAccessControlVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>10.0.0-preview.5.25260.104</VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>
     <!-- wcf -->
     <SystemServiceModelVersion>8.1.2</SystemServiceModelVersion>
     <!-- winforms -->

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "10.0.100-preview.3.25201.16",
     "runtimes": {
       "dotnet": [
-        "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
+        "$(MicrosoftNETCorePlatformsVersion)"
       ]
     }
   },

--- a/src/windowsdesktop/src/bundle/Microsoft.WindowsDesktop.App.Bundle.bundleproj
+++ b/src/windowsdesktop/src/bundle/Microsoft.WindowsDesktop.App.Bundle.bundleproj
@@ -34,8 +34,8 @@
 
       <NETCoreAppInstallerMsiRID
         Id="VS.Redist.Common.NetCore.%(InsertionName).%(Arch).10.0"
-        Version="$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
-        MsiFileName="dotnet-%(Name)-$(MicrosoftNETCoreAppRuntimewinx64Version)-%(Identity).msi" />
+        Version="$(MicrosoftNETCorePlatformsVersion)"
+        MsiFileName="dotnet-%(Name)-$(MicrosoftNETCoreAppRefVersion)-%(Identity).msi" />
 
       <PackageDownload Include="@(NETCoreAppInstallerMsiRID -> '%(Id)')" Version="[%(Version)]" />
     </ItemGroup>


### PR DESCRIPTION
This avoids need for a workaround in VMR builds and reduces friction for stable builds. When building non-win-x64 verticals, we end up having to set the x64 runtime pack and x64 VS redist pack properties (stable and non-stable properties) based on other values in the VMR orchestrator. Instead, use MicrosoftNEtCoreAppRef as the stable version property, and MicrosoftNETCOrePlatforms as the non-stable one.