### PR TITLE
Use platformmanifest file generated by the arcade

### DIFF
--- a/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
+++ b/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj
@@ -9,7 +9,6 @@
     <InstallerName>windowsdesktop-targeting-pack</InstallerName>
     <InstallerRuntimeIdentifiers>win-x64;win-x86;win-arm64</InstallerRuntimeIdentifiers>
     <VSInsertionShortComponentName>WindowsDesktop.TargetingPack</VSInsertionShortComponentName>
-    <CreatePlatformManifest Condition="'$(PreReleaseVersionLabel)' == 'servicing'">false</CreatePlatformManifest>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
   </PropertyGroup>
@@ -32,9 +31,5 @@
 
   <!-- Windows Forms validation and packaging -->
   <Import Project="WindowsForms.Packaging.targets" />
-
-  <ItemGroup Condition="'$(CreatePlatformManifest)' == 'false'">
-    <FilesToPackage Include="PlatformManifest.txt" TargetPath="data" GeneratedBuildFile="true" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Do not pin package versions to the GA release, keep them up-to-date with the latest servicing release. This was a design decision by PMs in the runtime team. This is also the default arcade behavior, thus we now let it generate the manifest. Previously we were checking in platformManifest.txt file generated at the GA time into the servicing branches. We shouldn't do it anymore.
Related to https://github.com/dotnet/windowsdesktop/issues/4991