### PR TITLE
Update image to vs2022 in release8.0

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -55,7 +55,7 @@ jobs:
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
       name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals windows.vs2019.amd64
+      demands: ImageOverride -equals windows.vs2022.amd64
   steps:
   - checkout: self
     clean: true

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -54,7 +54,7 @@ jobs:
       # If it's not devdiv, it's dnceng
       ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2019.amd64
+        demands: ImageOverride -equals windows.vs2022.amd64
 
   steps:
     - ${{ if ne(parameters.SkipLocProjectJsonGeneration, 'true') }}:

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -59,7 +59,7 @@ jobs:
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
       name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals windows.vs2019.amd64
+      demands: ImageOverride -equals windows.vs2022.amd64
 
   steps:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -30,10 +30,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2019.amd64.open
+        demands: ImageOverride -equals windows.vs2022.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2019.amd64
+        demands: ImageOverride -equals windows.vs2022.amd64
 
   steps:
   - ${{ each preStep in parameters.preSteps }}:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -108,7 +108,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
+          demands: ImageOverride -equals windows.vs2022.amd64
 
       steps:
         - template: setup-maestro-vars.yml
@@ -145,7 +145,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
+          demands: ImageOverride -equals windows.vs2022.amd64
       steps:
         - template: setup-maestro-vars.yml
           parameters:
@@ -199,7 +199,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
+          demands: ImageOverride -equals windows.vs2022.amd64
       steps:
         - template: setup-maestro-vars.yml
           parameters:
@@ -259,7 +259,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
+          demands: ImageOverride -equals windows.vs2022.amd64
       steps:
         - template: setup-maestro-vars.yml
           parameters:

--- a/eng/pipelines/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/jobs/prepare-signed-artifacts.yml
@@ -8,7 +8,7 @@ jobs:
   dependsOn: ${{ parameters.dependsOn }}
   pool:
     name: NetCore1ESPool-Svc-Internal
-    demands: ImageOverride -equals windows.vs2019.amd64
+    demands: ImageOverride -equals windows.vs2022.amd64
   # Double the default timeout.
   timeoutInMinutes: 120
   workspace:

--- a/eng/pipelines/jobs/windows-build.yml
+++ b/eng/pipelines/jobs/windows-build.yml
@@ -12,10 +12,10 @@ jobs:
     pool:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        vmImage: 'windows-2019'
+        vmImage: 'windows-2022'
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals windows.vs2019.amd64
+        demands: ImageOverride -equals windows.vs2022.amd64
     strategy:
       matrix: 
         Debug:


### PR DESCRIPTION
The Internal -> Public code merge PR https://github.com/dotnet/windowsdesktop/pull/5133 is blocked due to "The Windows Server 2019 image will be removed on 2025-06-30"

![image](https://github.com/user-attachments/assets/2414160f-a147-4446-9463-41ed6c705282)
