### PR TITLE
[release/8.0] Update branding to 8.0.32

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>31</PatchVersion>
+    <PatchVersion>32</PatchVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0`.

**Changes:**
- Repository: windowsdesktop
  - PatchVersion: `31` -> `32`

**Files Modified:**
- eng/Versions.props (+1 -1)
